### PR TITLE
[태연] 250205

### DIFF
--- a/Softeer/20250205_징검다리2/rhino-ty.js
+++ b/Softeer/20250205_징검다리2/rhino-ty.js
@@ -1,0 +1,43 @@
+// 동적 계획법의 응용, 탑다운과 바텀업의 방식을 그대로 가져와야함
+// 최대 증가 수열과 최대 감소 수열을 구하고, 그 i번째가 꼭짓점으로서 최대 증가/감소하기 때문에 합치면 됨
+function solution(n, stones) {
+  // 각 위치까지의 증가하는 부분 수열의 길이를 저장
+  const incDP = new Array(n).fill(1);
+  // 각 위치부터의 감소하는 부분 수열의 길이를 저장
+  const decDP = new Array(n).fill(1);
+
+  // 증가하는 부분 수열 계산
+  for (let i = 1; i < n; i++) {
+    for (let j = 0; j < i; j++) {
+      if (stones[i] > stones[j]) {
+        incDP[i] = Math.max(incDP[i], incDP[j] + 1);
+      }
+    }
+  }
+
+  // 감소하는 부분 수열 계산 (뒤에서부터)
+  for (let i = n - 2; i >= 0; i--) {
+    for (let j = n - 1; j > i; j--) {
+      if (stones[i] > stones[j]) {
+        decDP[i] = Math.max(decDP[i], decDP[j] + 1);
+      }
+    }
+  }
+
+  // 각 위치에서의 바이토닉 수열 길이 계산
+  let maxLength = 0;
+  for (let i = 0; i < n; i++) {
+    // -1은 현재 위치가 증가와 감소 수열에서 중복되므로 빼줌
+    maxLength = Math.max(maxLength, incDP[i] + decDP[i] - 1);
+  }
+
+  return maxLength;
+}
+
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : './input.txt';
+const input = fs.readFileSync(filePath).toString().trim().split('\n');
+const N = parseInt(input[0]);
+const stones = input[1].split(' ').map(Number);
+
+console.log(solution(N, stones));

--- a/Softeer/20250205_징검다리2/rhino-ty.js
+++ b/Softeer/20250205_징검다리2/rhino-ty.js
@@ -1,38 +1,99 @@
 // 동적 계획법의 응용, 탑다운과 바텀업의 방식을 그대로 가져와야함
 // 최대 증가 수열과 최대 감소 수열을 구하고, 그 i번째가 꼭짓점으로서 최대 증가/감소하기 때문에 합치면 됨
+// 시간 복잡도를 줄이기 위해 이진 탐색 실행
 function solution(n, stones) {
-  // 각 위치까지의 증가하는 부분 수열의 길이를 저장
-  const incDP = new Array(n).fill(1);
-  // 각 위치부터의 감소하는 부분 수열의 길이를 저장
-  const decDP = new Array(n).fill(1);
+  // 증가하는 부분 수열을 저장할 배열
+  let incSequence = [];
+  // 현재까지의 증가 수열 길이를 저장할 배열
+  let incLength = new Array(n).fill(1);
 
-  // 증가하는 부분 수열 계산
-  for (let i = 1; i < n; i++) {
-    for (let j = 0; j < i; j++) {
-      if (stones[i] > stones[j]) {
-        incDP[i] = Math.max(incDP[i], incDP[j] + 1);
+  // 감소하는 부분 수열을 저장할 배열
+  let decSequence = [];
+  // 현재까지의 감소 수열 길이를 저장할 배열
+  let decLength = new Array(n).fill(1);
+
+  // 이진 탐색으로 위치를 찾는 함수
+  function binarySearch(arr, target) {
+    let left = 0;
+    let right = arr.length - 1;
+
+    while (left <= right) {
+      let mid = Math.floor((left + right) / 2);
+      if (arr[mid] >= target) {
+        right = mid - 1;
+      } else {
+        left = mid + 1;
       }
     }
+    return left;
   }
 
-  // 감소하는 부분 수열 계산 (뒤에서부터)
-  for (let i = n - 2; i >= 0; i--) {
-    for (let j = n - 1; j > i; j--) {
-      if (stones[i] > stones[j]) {
-        decDP[i] = Math.max(decDP[i], decDP[j] + 1);
-      }
+  // 증가 수열 계산
+  for (let i = 0; i < n; i++) {
+    let pos = binarySearch(incSequence, stones[i]);
+    if (pos === incSequence.length) {
+      incSequence.push(stones[i]);
+    } else {
+      incSequence[pos] = stones[i];
     }
+    incLength[i] = pos + 1;
   }
 
-  // 각 위치에서의 바이토닉 수열 길이 계산
+  // 감소 수열 계산, 뒤에서부터 계산
+  for (let i = n - 1; i >= 0; i--) {
+    let pos = binarySearch(decSequence, stones[i]);
+    if (pos === decSequence.length) {
+      decSequence.push(stones[i]);
+    } else {
+      decSequence[pos] = stones[i];
+    }
+    decLength[i] = pos + 1;
+  }
+
+  // 각 위치에서의 최대 길이 계산
   let maxLength = 0;
   for (let i = 0; i < n; i++) {
-    // -1은 현재 위치가 증가와 감소 수열에서 중복되므로 빼줌
-    maxLength = Math.max(maxLength, incDP[i] + decDP[i] - 1);
+    maxLength = Math.max(maxLength, incLength[i] + decLength[i] - 1);
   }
 
   return maxLength;
 }
+
+// 아래 코드는 N이 최대 3×10^5이고 현재 알고리즘은 O(N^2)이라 시간 초과가 나는 문제 발생
+
+// function solution(n, stones) {
+//   // 각 위치까지의 증가하는 부분 수열의 길이를 저장
+//   const incDP = new Array(n).fill(1);
+//   // 각 위치부터의 감소하는 부분 수열의 길이를 저장
+//   const decDP = new Array(n).fill(1);
+
+//   // 증가하는 부분 수열 계산
+//   for (let i = 1; i < n; i++) {
+//     for (let j = 0; j < i; j++) {
+//       if (stones[i] > stones[j]) {
+//         incDP[i] = Math.max(incDP[i], incDP[j] + 1);
+//       }
+//     }
+//   }
+
+//   // 감소하는 부분 수열 계산 (뒤에서부터)
+//   for (let i = n - 2; i >= 0; i--) {
+//     for (let j = n - 1; j > i; j--) {
+//       if (stones[i] > stones[j]) {
+//         decDP[i] = Math.max(decDP[i], decDP[j] + 1);
+//       }
+//     }
+//   }
+
+//   // 각 위치에서의 바이토닉 수열 길이 계산
+//   let maxLength = 0;
+//   for (let i = 0; i < n; i++) {
+//     // -1은 현재 위치가 증가와 감소 수열에서 중복되므로 빼줌
+//     maxLength = Math.max(maxLength, incDP[i] + decDP[i] - 1);
+//   }
+
+//   return maxLength;
+// }
 
 const fs = require('fs');
 const filePath = process.platform === 'linux' ? '/dev/stdin' : './input.txt';

--- a/Softeer/20250205_출퇴근길/rhino-ty.js
+++ b/Softeer/20250205_출퇴근길/rhino-ty.js
@@ -1,0 +1,82 @@
+// 1. 입력받은 간선들로 그래프 생성, 인접 리스트 방식으로 구현 (방향 그래프이므로 단방향으로만 연결)
+// 2. S에서 도달 가능한 정점들을 찾는 함수 구현
+//   - S를 시작점으로 하는 DFS를 수행 => 모든 경로를 찾는데 최적화
+//   - 각 정점에서 T까지 도달 가능한지도 체크
+//   - S에서 해당 정점을 거쳐 T까지 갈 수 있는 정점들의 집합을 반환
+// 3. T에서 도달 가능한 정점들을 찾는 함수 구현
+//   - T를 시작점으로 하는 DFS를 수행 => 모든 경로를 찾는데 최적화
+//   - 각 정점에서 S까지 도달 가능한지도 체크
+//   - T에서 해당 정점을 거쳐 S까지 갈 수 있는 정점들의 집합을 반환
+// 4. 2번과 3번에서 구한 두 집합에 모두 포함된 정점들의 개수가 답이 된다
+
+// - 단순히 양방향으로 도달 가능한지만 체크하는 것이 아니라, 해당 정점을 거쳐서 최종 목적지(T 또는 S)까지 도달 가능한지를 확인해야 함
+// - 사이클이 있을 수 있으므로 방문 체크 필요
+
+function solution(N, M, edges, S, T) {
+  // 두 개의 그래프 - 정방향과 역방향
+  const graph = Array.from({ length: N + 1 }, () => []);
+  const reverseGraph = Array.from({ length: N + 1 }, () => []);
+
+  // 간선 정보로 그래프 구성
+  for (const [from, to] of edges) {
+    graph[from].push(to); // 정방향 간선 추가
+    reverseGraph[to].push(from); // 역방향 간선 추가
+  }
+
+  // DFS로 방문 가능한 노드들을 찾는 함수
+  // 재귀 호출 초과로 런타임 에러, 스택으로 변경
+  function dfs(start, graph, visited) {
+    const stack = [start];
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (visited[current]) continue;
+
+      visited[current] = true;
+      for (const next of graph[current]) {
+        if (!visited[next]) {
+          stack.push(next);
+        }
+      }
+    }
+  }
+
+  // 출근길에서 방문 가능한 노드들 체크
+  const fromStart = Array(N + 1).fill(false);
+  fromStart[T] = true; // 도착점은 미리 방문 처리 (마지막에만 방문해야 하므로)
+  dfs(S, graph, fromStart);
+
+  // 도착점에서 방문 가능한 노드들 체크
+  const toEnd = Array(N + 1).fill(false);
+  dfs(T, reverseGraph, toEnd);
+
+  // 퇴근길에서 방문 가능한 노드들 체크
+  const fromEnd = Array(N + 1).fill(false);
+  fromEnd[S] = true; // 도착점은 미리 방문 처리
+  dfs(T, graph, fromEnd);
+
+  // 시작점에서 방문 가능한 노드들 체크
+  const toStart = Array(N + 1).fill(false);
+  dfs(S, reverseGraph, toStart);
+
+  // 모든 조건을 만족하는 노드 개수 세기
+  let answer = 0;
+  for (let i = 1; i <= N; i++) {
+    // 모든 조건을 만족하는 노드만 카운트
+    if (fromStart[i] && fromEnd[i] && toStart[i] && toEnd[i]) {
+      answer++;
+    }
+  }
+
+  // S와 T는 제외해야 하므로 2를 뺌
+  return answer - 2;
+}
+
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : './input.txt';
+const input = fs.readFileSync(filePath).toString().trim().split('\n');
+const [N, M] = input[0].split(' ').map(Number);
+const edges = input.slice(1, M + 1).map((line) => line.split(' ').map(Number));
+const [S, T] = input[M + 1].split(' ').map(Number);
+
+console.log(solution(N, M, edges, S, T));


### PR DESCRIPTION
# 징검다리2

- 문제 이슈 넘버: #16 

## 문제 이해
동적 계획법의 응용 문제임

- 징검다리는 서쪽에서 동쪽으로 놓여있음, 돌의 높이는 모두 다름
- 철수는 서쪽에서 동쪽으로 이동하면서 처음에는 높이가 점점 높은 돌을 밟고 어느 지점부터는 높이가 점점 낮은 돌을 밟아야 함
- 최대한 많은 돌을 밟으려 할 때, 밟을 수 있는 돌의 최대 개수를 구하는 문제
- 1 ≤ N ≤ 3×10^5 인 정수, 1 ≤ Ai ≤ 10^8 를 2초 안으로 해결
- 즉, 시간초과에 주의해야 함 (O(N²) 사용 불가) => 이걸 몰라서 시간 초과 됐음

## 시도
1. **문제 분석**
   - "산" 모양의 수열을 찾는 문제 -> 바이토닉 수열(Bitonic Sequence)을 뜻함
   - 각 돌(`i`)을 기준으로 "왼쪽에서의 증가 수열 길이"와 "오른쪽에서의 감소 수열 길이"를 구해야 함

2. **첫 번째 시도 (O(N^2) - 시간초과)**
   - 동적 계획법을 사용한 기본적인 접근
   - 각 위치마다 이전/이후의 모든 돌을 검사
   - N이 최대 3×10^5이므로 시간초과 발생

3. **최적화된 해결방법 (O(NlogN))**
   - 이진 탐색을 활용하여 시간복잡도 개선
   - [Lower Bound](https://yoongrammer.tistory.com/105) 개념을 사용해 증가/감소 수열의 위치를 빠르게 찾음

## 복잡도
- 시간복잡도: O(NlogN)
  - 각 원소마다 이진 탐색: O(logN)
  - 전체 원소 순회: O(N)
  
- 공간복잡도: O(N)
  - incLength, decLength 배열: O(N)
  - incSequence, decSequence 배열: O(N)

## 코드 설명
```javascript
// 이진 탐색으로 위치를 찾는 함수
function binarySearch(arr, target) {
    let left = 0;
    let right = arr.length - 1;
    
    while (left <= right) {
        let mid = Math.floor((left + right) / 2);
        if (arr[mid] >= target) {
            right = mid - 1;
        } else {
            left = mid + 1;
        }
    }
    return left;
}
```
- Lower Bound를 찾는 이진 탐색 구현
- `target`이 들어갈 수 있는 가장 왼쪽 위치를 반환

```javascript
// 증가 수열과 감소 수열 각각 계산
for (let i = 0; i < n; i++) {
    let pos = binarySearch(incSequence, stones[i]);
    if (pos === incSequence.length) {
        incSequence.push(stones[i]);
    } else {
        incSequence[pos] = stones[i];
    }
    incLength[i] = pos + 1;
}
```
- 각 위치에서 이진 탐색으로 삽입 위치를 찾음
- 현재 값이 들어갈 수 있는 최적의 위치를 O(logN)에 찾아냄

---

# 출퇴근길

- 문제 이슈 넘버: #17

## 문제 이해
한 방향으로만 이동할 수 있는 도로들이 주어졌을 때, 출근길(S→T)과 퇴근길(T→S) 모두에서 방문할 수 있는 정점의 개수를 찾는 문제임

- 출근길에서 T는 반드시 마지막에 한 번만 방문
- 퇴근길에서 S는 반드시 마지막에 한 번만 방문
- 그 외의 정점들은 여러 번 방문 가능

## 시도
1. **첫 번째 시도 (BFS + 경로 추적 - 실패)**
   - BFS를 사용해 모든 가능한 경로를 탐색하면서 각 경로에 포함된 정점들을 추적하는 방식
   - 한 노드를 여러 번 방문할 수 있음과 정방향-역방향 노드 기록을 놓침

2. **두 번째 시도 (DFS 재귀 - 실패)**
   - 단순히 정점들의 방문 여부만 체크하는 방식으로 접근
   - JavaScript의 재귀 호출 제한(10000번 이하)으로 인한 런타임 에러 발생

3. **최종 해결 방법 (반복문 DFS)**
   - 스택을 사용한 반복문 형태의 DFS로 구현
   - 재귀 호출의 장점(깊이 우선 탐색)을 유지하면서 콜 스택 제한 회피

## 알고리즘 설계
이 문제는 네 가지 다른 방향의 도달 가능성을 모두 확인해야함

1. **정방향 그래프 탐색**
   - S에서 출발하여 갈 수 있는 노드들 (`fromStart`)
   - T에서 출발하여 갈 수 있는 노드들 (`fromEnd`)

2. **역방향 그래프 탐색**
   - T로 도달할 수 있는 노드들 (`toEnd`)
   - S로 도달할 수 있는 노드들 (`toStart`)

## 복잡도
- 시간복잡도: O(V + E)
  - V: 정점의 개수
  - E: 간선의 개수
  - DFS를 4번 수행하므로 총 O(4(V + E)), 극단으로 가면 = O(V + E)
- 공간복잡도: O(V + E)
  - 그래프 저장: O(V + E)
  - 방문 배열: O(V)
  - 스택 공간: 최악의 경우 O(V)

## 코드 설명
```javascript
// 그래프 초기화
const graph = Array.from({ length: N + 1 }, () => []);
const reverseGraph = Array.from({ length: N + 1 }, () => []);
```
- 정방향과 역방향, 두 개의 그래프를 인접 리스트로 구현
- 인덱스가 1부터 시작하므로 길이를 N+1로 설정

```javascript
function dfs(start, graph, visited) {
    const stack = [start];
    while (stack.length > 0) {
        const current = stack.pop();
        if (visited[current]) continue;
        visited[current] = true;
        for (const next of graph[current]) {
            if (!visited[next]) stack.push(next);
        }
    }
}
```
- 재귀 대신 스택을 사용한 반복문 형태의 DFS
- 방문한 노드는 재방문하지 않도록 체크
- 스택에 다음 방문할 노드들을 추가하며 진행

Node.js의 재귀 호출 제한을 처음 앎,, 역방향 간선을 주면 엄청 간단해진다는 것도 알았음