### PR TITLE
[다솔] 250210

### DIFF
--- a/Softeer/20250210_점수따먹기/dbjoung.js
+++ b/Softeer/20250210_점수따먹기/dbjoung.js
@@ -1,0 +1,29 @@
+const [NM, ...inputs] = require("fs")
+  .readFileSync(0)
+  .toString()
+  .trim()
+  .split("\n");
+const [N, M] = NM.split(" ").map(Number);
+const nums = Array.from(inputs, (line) => line.split(" ").map(Number));
+const d = nums.map((row) => [0, ...row]);
+d.unshift(new Array(M + 1).fill(0));
+
+let maxSum = -10001;
+for (let r = 1; r <= N; r++) {
+  for (let c = 1; c <= M; c++) {
+    d[r][c] += d[r - 1][c] + d[r][c - 1] - d[r - 1][c - 1];
+  }
+}
+
+for (let r1 = 1; r1 <= N; r1++) {
+  for (let c1 = 1; c1 <= M; c1++) {
+    for (let r = r1; r <= N; r++) {
+      for (let c = c1; c <= M; c++) {
+        const sum = d[r][c] - d[r1 - 1][c] - d[r][c1 - 1] + d[r1 - 1][c1 - 1];
+        maxSum = Math.max(sum, maxSum);
+      }
+    }
+  }
+}
+
+console.log(maxSum);


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #23 

### 조건
- 2차원 배열이 입력으로 주어지고, 배열 내 부분행렬 중 값의 합이 가장 큰 행렬의 합을 구해야 한다.
- N, M 최대값 : 30
- 메모리 : 124mb
- 배열 요소값 범위 : -30000~30000

### 풀이 방법
- 인덱스 (1,1) 부터 (n, m) 까지의 부분 행렬의 합을 구하는 것은 dp 활용한 누적합으로 쉽게 해결된다.
	- 점화식 : d[a][b] = d[a-1][b] + d[a][b-1] - d[a-1][b-1]
- 하지만 모든 부분 행렬의 합을 비교해야하므로, 2차원 배열로 모든 행렬을 순회하며 d 배열을 활용해 요소 합을 구하도록 한다.
	- 부분행렬([a1, b1] 칸부터 [a, b] 칸까지) 요소 합 : d[a][b] - d[a1-1][b] - d[a][b1-1] + d[a1-1][b1-1]
- 4중 for문이 되어버리지만 30x30x30x30 = 810,000 이기 때문에 시간 제한 2초 안에 충분히 풀 수 있을 것이라 생각했다.

### 시간&메모리 어림추산
- 소요 시간 : 30x30x30x30=810,000 (약 0.0081초) 
- 메모리 : - 

### 실제 소요 시간 & 메모리
- 소요 시간 : 2552ms (0.2ms)
- 메모리 : 12972 KB