### PR TITLE
[다솔] 250212

### DIFF
--- a/Backjoon/250212_개똥벌레/dbjoung.js
+++ b/Backjoon/250212_개똥벌레/dbjoung.js
@@ -1,0 +1,52 @@
+function calcCount(rocks, numOfRock, H) {
+  const tracks = new Array(H + 1).fill(0);
+  const maxLength = rocks[numOfRock];
+
+  for (let track = 1; track <= maxLength; track++) {
+    let left = 1;
+    let right = numOfRock;
+    while (left < right) {
+      const half = Math.floor((left + right) / 2);
+      if (track <= rocks[half]) right = half;
+      else left = half + 1;
+    }
+
+    tracks[track] = numOfRock - (left - 1);
+  }
+  //트랙별 개수 이분 탐색.
+
+  return tracks;
+}
+
+const [nh, ...inputs] = require("fs")
+  .readFileSync(0)
+  .toString()
+  .trim()
+  .split("\n");
+
+const [N, H] = nh.split(" ").map(Number);
+const upRock = [0];
+const downRock = [0];
+
+for (let i = 1; i <= N; i++) {
+  if (i % 2 == 0) upRock.push(Number(inputs[i - 1]));
+  else downRock.push(Number(inputs[i - 1]));
+}
+
+upRock.sort((a, b) => a - b);
+downRock.sort((a, b) => a - b);
+
+const upResult = calcCount(upRock, N / 2, H);
+const downResult = calcCount(downRock, N / 2, H);
+
+let minSum = N;
+let count = 0;
+for (let i = 1; i <= H; i++) {
+  const sum = downResult[i] + upResult[H - i + 1];
+  if (minSum > sum) {
+    minSum = sum;
+    count = 1;
+  } else if (minSum == sum) count += 1;
+}
+
+console.log(minSum, count);


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #23 

### 조건
- 개똥벌레는 무조건 일직선으로 날아간다. 마주치는 종유석과 석순을 전부 부순다. 개똥벌레가 최소로 부수는 개수와, 최소인 트랙이 몇 개 있는 지를 구해야 한다.
- 완전 탐색이나 2차원 DP를 사용해서 풀 수 있겠지만, N과 M의 최대값이 각각 200,000, 500,000 이라서 불가능하다. (총 100000000000회 반복하게 됨.)
- 시간 복잡도가 O(N제곱) 보다 적은 방법을 생각해야 한다. 

### 풀이 방법
- 개똥벌레는 트랙을 무조건 완주하기 때문에, 석순은 석순 끼리, 종유석은 종유석 끼리 자리를 바꿔도 결과가 바뀌지 않는다.
- 각 트랙별 개똥벌레가 부수는 석순과 종유석 수를 각각 계산한 후 합친다. 
- 석순과 종유석의 크기가 오름차순으로 정렬되어있다면, 이분탐색을 활용해 트랙별 부수는 개수를 빠르게 계산할 수 있다.
- 예를 들어 3번 트랙에서 개똥벌레가 달릴 경우, 개똥벌레는 길이가 3 이상인 석순(종유석)만 부술 수 있다. 따라서 전체 석순(종유석)의 개수에서 길이가 3 미만인 석순(종유석)이 몇 개 있는지 계산하여 빼주면 된다.
- 즉, track[i] = N/2 - (i보다 크기가 작은 석순(종유석)의 개수)
- for문을 돌려서 'i보다 크기가 작은 석순(종유석)의 개수'를 직접 세어줘도 괜찮지만, 아마 이러면 시간 초과가 발생할 것이다. 따라서 이분탐색을 활용해 석순(종유석)의 크기 배열에서 i가 몇 번째 자리에 위치하는 지 구하면, (그 인덱스 - 1) 이 곧 'i보다 크기가 작은 석순(종유석)의 개수'가 된다.

***MEMO***
- 오름차순 정렬 : Array.prototype.sort() 를 사용했다. 일반적으로 NlogN의 시간복잡도를 가지지만 어떤 JS 엔진을 쓰느냐에 따라 시간 복잡도가 달라진다고 한다. 만약 시간 초과가 난다면 직접 힙 정렬을 구현해 사용하면 될 것 같다.
- 다만, sort() 메소드 사용 방법을 착각해 오랜 시간 헤맸다. sort()로 정수 정렬을 해줄 때에는 꼭 대소비교를 하는 핸들러를 인자로 넘겨주자.

### 시간복잡도 어림추산
- 200,000log200,000(석순,종유석 정렬) + 500,000log200,000(track개수만큼 이분탐색) = 3,521,928 + 3,786,313 = 7,308,214