### PR TITLE
[미라] 250212

### DIFF
--- a/Backjoon/250212_개똥벌레/ssum1ra.py
+++ b/Backjoon/250212_개똥벌레/ssum1ra.py
@@ -1,0 +1,24 @@
+n, h = map(int, input().split())
+s = [int(input()) for _ in range(n)]
+
+temp = [0] * h
+
+for i in range(n):
+    if i % 2 == 0:
+        for j in range(s[i]):
+            temp[j] += 1
+    else:
+        for j in range(h - 1, h - 1 - s[i], -1):
+            temp[j] += 1
+
+min = float('inf')
+cnt = 0
+for i in range(len(temp)):
+    if temp[i] < min:
+        min = temp[i]
+
+for i in range(len(temp)):
+    if temp[i] == min:
+        cnt += 1
+
+print(min, cnt)

--- a/Backjoon/250212_개똥벌레/ssum1ra.py
+++ b/Backjoon/250212_개똥벌레/ssum1ra.py
@@ -1,24 +1,41 @@
-n, h = map(int, input().split())
-s = [int(input()) for _ in range(n)]
+import sys
+input = sys.stdin.readline
 
-temp = [0] * h
+n, h = map(int, input().split())
+
+t = [0] * (n//2)
+d = [0] * (n//2)
 
 for i in range(n):
     if i % 2 == 0:
-        for j in range(s[i]):
-            temp[j] += 1
+        d[i//2] = int(input())
     else:
-        for j in range(h - 1, h - 1 - s[i], -1):
-            temp[j] += 1
+        t[i//2] = int(input())
 
-min = float('inf')
+t_h = [0] * (h+1)
+d_h = [0] * (h+1)
+
+for i in range(n//2):
+    t_h[t[i]] += 1
+    d_h[d[i]] += 1
+
+dp_t = [0] * (h+1)
+dp_d = [0] * (h+1)
+dp_t[h] = t_h[h]
+dp_d[h] = d_h[h]
+for i in range(h - 1, 0, -1):
+    dp_t[i] = dp_t[i+1] + t_h[i]
+    dp_d[i] = dp_d[i+1] + d_h[i]
+
+min_s = float('inf')
+s = [0] * (h+1)
+for i in range(1, h + 1):
+    s[i] = dp_d[i] + dp_t[h + 1 - i]
+    min_s = min(s[i], min_s)
+
 cnt = 0
-for i in range(len(temp)):
-    if temp[i] < min:
-        min = temp[i]
-
-for i in range(len(temp)):
-    if temp[i] == min:
+for i in range(1, h + 1):
+    if s[i] == min_s:
         cnt += 1
 
-print(min, cnt)
+print(min_s, cnt)


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #31 

## 접근법 1
![image](https://github.com/user-attachments/assets/76673ac2-1804-4f67-8b91-dc824c31ed2c)

- n개의 장애물을 하나씩 확인하면서 장애물의 높이만큼 배열을 업데이트한다.
- 최악의 경우, 장애물의 높이가 h에 가까우면 O(h)번 실행된다.
- 전체 n개의 장애물에 대해 실행되므로 총 O(n * h) 연산이 필요하다.

### 문제
- 시간 복잡도가 O(n * h)
- 최악의 경우(n = 200,000, h = 500,000)에 맞춰 보면 10¹¹번(1000억 번) 이상의 연산이 발생할 수 있어 1초 안에 해결할 수 없다.

## 접근법2
> [!IMPORTANT]
> h = 5,
> - **1구역에서 파괴해야 하는 장애물 개수**  
>   - 바닥의 높이 `1, 2, 3, 4, 5`의 방해물 개수 + 천장의 높이 `5` 방해물 개수  
> - **2구역에서 파괴해야 하는 장애물 개수**  
>   - 바닥의 높이 `2, 3, 4, 5`의 방해물 개수 + 천장의 높이 `4, 5` 방해물 개수  
> .
> .
> .
> - **5구역에서 파괴해야 하는 장애물 개수**  
>   - 바닥의 높이 `5`의 방해물 개수 + 천장의 높이 `1, 2, 3, 4, 5` 방해물 개수  

- 입력 시, 종유석과 석순을 각각 다른 배열에 저장한다.
  - 종유석(천장) → t[]
  - 석순(바닥) → d[]
- 종유석과 석순의 높이별 개수를 기록한다.
  - `t_h[i]` : 높이가 i인 종유석의 개수
  - `d_h[i]` : 높이가 i인 석순의 개수
- 역방향 누적합 계산을 통해 충돌 개수를 누적한다.
  - `dp_d[i] = dp_d[i+1] + d_h[i]` : 바닥의 높이 `i, i + 1, ..., h` 방해물의 개수 
  - `dp_t[i] = dp_t[i+1] + t_h[i]` : 천장의 높이 `i, i + 1, ..., h` 방해물의 개수
  - i 구역에서는 높이가 i 이상인 모든 방해물이 영향을 끼치기 때문이다.
- i 구역에서 부딪히는 총 장애물 개수를 계산한다.
  - `s[i] = dp_d[i] + dp_t[h + 1 - i]` : 바닥의 높이 `i, i-1, ..., h`의 방해물 개수 + 천장의 높이 `h + 1 - i, ..., h` 방해물 개수   

### 해결
- 시간 복잡도가 O(n + h)
- 최악의 경우(n = 200,000, h = 500,000)에도 O(700,000), 즉 1초 안에 충분히 해결 가능하다.