### PR TITLE
[다솔] 250217

### DIFF
--- a/Backjoon/250217_N-Queen/dbjoung.js
+++ b/Backjoon/250217_N-Queen/dbjoung.js
@@ -1,0 +1,40 @@
+function check(row, col, value) {
+  checkRow[row] = value;
+  checkCol[col] = value;
+  checkDiag[row + col] = value;
+  checkReDiag[row - col + (N - 1)] = value;
+}
+
+function dfs(row, count) {
+  if (count == N) result++;
+  if (row >= N) return;
+  for (let col = 0; col < N; col++) {
+    if (
+      !checkRow[row] &&
+      !checkCol[col] &&
+      !checkDiag[row + col] &&
+      !checkReDiag[row - col + (N - 1)]
+    ) {
+      check(row, col, true);
+      dfs(row + 1, count + 1);
+      check(row, col, false);
+    }
+  }
+}
+
+const N = Number(require("fs").readFileSync(0).toString().trim());
+
+const map = new Array(N).fill(null).map(() => new Array(N).fill(false));
+const checkRow = new Array(N).fill(false);
+const checkCol = new Array(N).fill(false);
+const checkDiag = new Array(N * 2).fill(false);
+const checkReDiag = new Array(N * 2).fill(false);
+let result = 0;
+
+for (let col = 0; col < N; col++) {
+  check(0, col, true);
+  dfs(1, 1);
+  check(0, col, false);
+}
+
+console.log(result);


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #41 

### 조건
- NxN 보드판에 퀸 N개를 서로 잡을 수 없는 위치를 놓는 경우의 수 구하기

### 풀이 방법
- dfs로 완전탐색하며 조건에 맞는 가지수를 구한다.
- dfs 함수가 중첩될 때 마다 row인덱스를 한칸 전진한다.
- dfs 함수 내에서는 col 인덱스를 for 문 돌리며 순회한다.
- 퀸을 놓을 수 있는 칸이라면, 퀸을 놓고 다음 row로 넘어간다.
- 퀸을 놓을 수 있는 조건
	- 현재 칸의 가로 줄에 아무것도 놓여있지 않음 (row 값이 같음)
	- 현재 칸의 세로 줄에 아무것도 놓여있지 않음 (col 값이 같음)
	- 현재 칸과 대각선인 줄에 아무것도 놓여있지 않음 (row+col 값이 같음)
	- 현재 칸과 역대각선인 줄에 아무것도 놓여있지 않음 (row-col 값이 같음)
- 위 조건에 해당하는 배열을 각각 생성해 방문 배열로 사용하였음.

### 시간&메모리 어림추산
- N개의 줄에서 각 줄 당 칸 하나씩 고르므로, 시간 복잡도는 N<sup>N</sup>. 
- 15<sup>15</sup>이 최대값이므로, 적어도 100억회 연산... 시간복잡도 어떻게 통과했지?
	- 생각해보니 퀸 놓는 조건에 해당하지 않는 경우의 수는 전부 탐색하지 않고 IF문으로 걸러짐.
    

### 실제 소요 시간 & 메모리
- 10992 KB / 4040ms