### PR TITLE
[다솔] 250220

### DIFF
--- a/Programmers/250220_가장_많이_받은_선물/dbjoung.js
+++ b/Programmers/250220_가장_많이_받은_선물/dbjoung.js
@@ -1,0 +1,72 @@
+function pop(list, value) {
+  for (let i = 0; i < list.length; i++) {
+    if (list[i] == value) list.splice(i, 1);
+  }
+}
+
+function bfs(startNode, map, visit) {
+  const queue = [];
+
+  queue.push(startNode);
+  visit[startNode] = true;
+
+  while (queue.length > 0) {
+    const curNode = queue.shift();
+    if (map[curNode].length == 0) continue;
+    for (const nextNode of map[curNode]) {
+      if (visit[nextNode]) continue;
+      visit[nextNode] = true;
+      queue.push(nextNode);
+    }
+  }
+}
+
+function solution(edges) {
+  const map = new Array(1000001).fill(null).map(() => []);
+  const rmap = new Array(1000001).fill(null).map(() => []);
+  const visit = new Array(1000001).fill(true);
+
+  let numOfNode = 0;
+  for (const edge of edges) {
+    map[edge[0]].push(edge[1]);
+    rmap[edge[1]].push(edge[0]);
+    visit[edge[0]] = false;
+    visit[edge[1]] = false;
+    numOfNode = Math.max(numOfNode, edge[0], edge[1]);
+  }
+
+  const addedNode = map.findIndex(
+    (edge, i) => edge.length >= 2 && rmap[i].length == 0
+  );
+  map[addedNode].forEach((node) => {
+    pop(rmap[node], addedNode);
+  });
+
+  const lineGStarts = [];
+  const EGCenters = [];
+
+  for (let nodeIndex = 1; nodeIndex <= numOfNode; nodeIndex++) {
+    if (visit[nodeIndex]) continue;
+    if (map[nodeIndex].length == 2 && rmap[nodeIndex].length == 2)
+      EGCenters.push(nodeIndex);
+    else if (map[nodeIndex].length <= 1 && rmap[nodeIndex].length == 0)
+      lineGStarts.push(nodeIndex);
+  }
+
+  lineGStarts.forEach((node) => {
+    bfs(node, map, visit);
+  });
+  EGCenters.forEach((node) => {
+    bfs(node, map, visit);
+  });
+
+  let donuts = 0;
+  for (let i = 1; i <= numOfNode; i++) {
+    if (visit[i] || i == addedNode) continue;
+    bfs(i, map, visit);
+    donuts++;
+  }
+
+  var answer = [addedNode, donuts, lineGStarts.length, EGCenters.length];
+  return answer;
+}

--- a/Programmers/250220_가장_많이_받은_선물/dbjoung.js
+++ b/Programmers/250220_가장_많이_받은_선물/dbjoung.js
@@ -1,72 +1,46 @@
-function pop(list, value) {
-  for (let i = 0; i < list.length; i++) {
-    if (list[i] == value) list.splice(i, 1);
+function solution(friends, gifts) {
+  const fds = new Array(friends.length).fill(null);
+  const ids = {};
+  const infos = new Array(friends.length)
+    .fill(null)
+    .map(() => new Array(friends.length).fill(0));
+
+  for (let index = 0; index < friends.length; index++) {
+    ids[friends[index]] = index;
   }
-}
 
-function bfs(startNode, map, visit) {
-  const queue = [];
+  for (const friend of friends) {
+    fds[ids[friend]] = { give: 0, take: 0, point: 0 };
+  }
 
-  queue.push(startNode);
-  visit[startNode] = true;
+  for (const gift of gifts) {
+    const [send, to] = gift.split(" ");
+    infos[ids[send]][ids[to]] += 1;
+    fds[ids[send]].give++;
+    fds[ids[to]].take++;
+  }
 
-  while (queue.length > 0) {
-    const curNode = queue.shift();
-    if (map[curNode].length == 0) continue;
-    for (const nextNode of map[curNode]) {
-      if (visit[nextNode]) continue;
-      visit[nextNode] = true;
-      queue.push(nextNode);
+  for (const fd of fds) {
+    fd.point = fd.give - fd.take;
+    fd.take = 0;
+  }
+
+  for (let sender = 0; sender < friends.length - 1; sender++) {
+    for (let taker = sender + 1; taker < friends.length; taker++) {
+      if (sender == taker) continue;
+      if (infos[sender][taker] == infos[taker][sender]) {
+        if (fds[sender].point > fds[taker].point) fds[sender].take++;
+        else if (fds[sender].point < fds[taker].point) fds[taker].take++;
+      } else if (infos[sender][taker] > infos[taker][sender])
+        fds[sender].take++;
+      else fds[taker].take++;
     }
   }
-}
 
-function solution(edges) {
-  const map = new Array(1000001).fill(null).map(() => []);
-  const rmap = new Array(1000001).fill(null).map(() => []);
-  const visit = new Array(1000001).fill(true);
-
-  let numOfNode = 0;
-  for (const edge of edges) {
-    map[edge[0]].push(edge[1]);
-    rmap[edge[1]].push(edge[0]);
-    visit[edge[0]] = false;
-    visit[edge[1]] = false;
-    numOfNode = Math.max(numOfNode, edge[0], edge[1]);
+  let result = 0;
+  for (const fd of fds) {
+    result = Math.max(fd.take, result);
   }
 
-  const addedNode = map.findIndex(
-    (edge, i) => edge.length >= 2 && rmap[i].length == 0
-  );
-  map[addedNode].forEach((node) => {
-    pop(rmap[node], addedNode);
-  });
-
-  const lineGStarts = [];
-  const EGCenters = [];
-
-  for (let nodeIndex = 1; nodeIndex <= numOfNode; nodeIndex++) {
-    if (visit[nodeIndex]) continue;
-    if (map[nodeIndex].length == 2 && rmap[nodeIndex].length == 2)
-      EGCenters.push(nodeIndex);
-    else if (map[nodeIndex].length <= 1 && rmap[nodeIndex].length == 0)
-      lineGStarts.push(nodeIndex);
-  }
-
-  lineGStarts.forEach((node) => {
-    bfs(node, map, visit);
-  });
-  EGCenters.forEach((node) => {
-    bfs(node, map, visit);
-  });
-
-  let donuts = 0;
-  for (let i = 1; i <= numOfNode; i++) {
-    if (visit[i] || i == addedNode) continue;
-    bfs(i, map, visit);
-    donuts++;
-  }
-
-  var answer = [addedNode, donuts, lineGStarts.length, EGCenters.length];
-  return answer;
+  return result;
 }

--- a/Programmers/250223_도넛과_막대_그래프/dbjoung.js
+++ b/Programmers/250223_도넛과_막대_그래프/dbjoung.js
@@ -1,0 +1,72 @@
+function pop(list, value) {
+  for (let i = 0; i < list.length; i++) {
+    if (list[i] == value) list.splice(i, 1);
+  }
+}
+
+function bfs(startNode, map, visit) {
+  const queue = [];
+
+  queue.push(startNode);
+  visit[startNode] = true;
+
+  while (queue.length > 0) {
+    const curNode = queue.shift();
+    if (map[curNode].length == 0) continue;
+    for (const nextNode of map[curNode]) {
+      if (visit[nextNode]) continue;
+      visit[nextNode] = true;
+      queue.push(nextNode);
+    }
+  }
+}
+
+function solution(edges) {
+  const map = new Array(1000001).fill(null).map(() => []);
+  const rmap = new Array(1000001).fill(null).map(() => []);
+  const visit = new Array(1000001).fill(true);
+
+  let numOfNode = 0;
+  for (const edge of edges) {
+    map[edge[0]].push(edge[1]);
+    rmap[edge[1]].push(edge[0]);
+    visit[edge[0]] = false;
+    visit[edge[1]] = false;
+    numOfNode = Math.max(numOfNode, edge[0], edge[1]);
+  }
+
+  const addedNode = map.findIndex(
+    (edge, i) => edge.length >= 2 && rmap[i].length == 0
+  );
+  map[addedNode].forEach((node) => {
+    pop(rmap[node], addedNode);
+  });
+
+  const lineGStarts = [];
+  const EGCenters = [];
+
+  for (let nodeIndex = 1; nodeIndex <= numOfNode; nodeIndex++) {
+    if (visit[nodeIndex]) continue;
+    if (map[nodeIndex].length == 2 && rmap[nodeIndex].length == 2)
+      EGCenters.push(nodeIndex);
+    else if (map[nodeIndex].length <= 1 && rmap[nodeIndex].length == 0)
+      lineGStarts.push(nodeIndex);
+  }
+
+  lineGStarts.forEach((node) => {
+    bfs(node, map, visit);
+  });
+  EGCenters.forEach((node) => {
+    bfs(node, map, visit);
+  });
+
+  let donuts = 0;
+  for (let i = 1; i <= numOfNode; i++) {
+    if (visit[i] || i == addedNode) continue;
+    bfs(i, map, visit);
+    donuts++;
+  }
+
+  var answer = [addedNode, donuts, lineGStarts.length, EGCenters.length];
+  return answer;
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #57 

- 각 캐릭터별 총 받은 선물 수, 준 선물 수를 통해 선물 Point를 구한다.
- 2차원 배열에 누가 누구에게 선물을 줬는 지 기록한다.
- 2차원 배열을 2중 for문으로 순회하면서 <sub>총 사람 수</sub>C<sub>2</sub> 쌍으로 조회한다.
- 둘 중 누가 선물을 받을 사람인지 판별 후, 사람 별 총 받은 선물 수를 기록한다.

- 가장 선물 많이 받은 사람 수를 출력한다.


---


### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #58 

### 조건
- 일자형, 팔자형, 도넛형 그래프가 그려진 상태에서, 노드 하나가 추가된 후 각 그래프의 랜덤한 노드 하나와 간선으로 이어진다.
- 추가한 노드의 번호, 그리고 각 그래프 종류별 개수를 구해야 한다.

### 풀이 방법
1-1. 방문 배열을 만든다. (전부 true로 초기화)
	- bfs에 사용할 방문배열. 
1-2. 인접리스트를 만든다. (순방향 1개, 역방향 1개)
	- 순방향으로 out 간선을, 역방향으로 in 간선 체크
	- 노드 번호가 순차적으로 지정되지 않기 때문에, 실제 존재하는 노드를 visit 배열에 false로 설정한다.
2. 추가 노드를 찾는다.
	- out 간선은 2개 이상이고, in 간선은 0개인 노드
3. 추가 노드의 간선들 삭제 
4. 8자형의 중심 노드s 찾음 : out 간선 2개, in 간선 2개
	- 해당 배열의 길이가 8자형 그래프의 개수다.
5. 1자형의 시작 노드s 찾음 : out 간선 1개 or 0개, in 간선 0개
	- 해당 배열의 길이가 일자형 그래프의 개수다.
6. 8자형 중심 노드, 1자형 중심 노드에서 bfs로 순회하며 vist 배열에 true로 체크한다. 
7. visit에 false 체크된 남은 노드들에 대해 bfs를 돌려 도넛형 그래프의 개수를 구한다.


### 시간&메모리 어림추산
- bfs로 모든 노드를 한번씩 들르기 때문에, 약 1,000,000회 예상.

### 실제 소요 시간 & 메모리
