### PR TITLE
[미라] 250303

### DIFF
--- a/Programmers/250303_산_모양_타일링/ssum1ra.py
+++ b/Programmers/250303_산_모양_타일링/ssum1ra.py
@@ -1,0 +1,22 @@
+def solution(n, tops):
+    answer = 0
+    
+    a = [0] * n
+    b = [0] * n
+    
+    a[0] = 1
+    b[0] = 3 if tops[0] else 2
+    
+    for i in range(1, n):
+        if tops[i]:
+            a[i] = a[i-1] + b[i-1]
+            b[i] = a[i-1] * 2 + b[i-1] * 3
+        else:
+            a[i] = a[i-1] + b[i-1] 
+            b[i] = a[i-1] + b[i-1] * 2
+        a[i] %= 10_007
+        b[i] %= 10_007
+    
+    answer = (a[n-1] + b[n-1]) % 10_007
+    
+    return answer


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #64 

## 타일 배치
![image](https://github.com/user-attachments/assets/70575c8a-48f9-4f2e-8220-37fa10769342)

- 1번 타일 : 위쪽 마름모 (a + c)
- 2번 타일 : 왼쪽 마름모 (b + c)
- 3번 타일 : 오른쪽 마름모 (c + d)
- 4번 타일 :  정삼각형 타일 

## 핵심 포인트
![image](https://github.com/user-attachments/assets/8d39576c-4008-4d84-b297-78bdfc4caea5)

- k-1번째의 3번 타일과 k번째의 1, 2, 4번 타일은 함께 놓일 수 없다. 

## 풀이 과정
- dp 활용
  - array_3 : k번째에 3번 타일을 배치한 경우의 수
  - array_124 : k번째에 1,2,4번 타일을 배치한 경우의 수

### tops[k]가 1인 경우
#### k번째에 3번 타일을 배치한 경우
![image](https://github.com/user-attachments/assets/9cda976f-7a61-4e06-8f87-9be7106c00c2)
- array_3[k] = array_3[k-1] + array_124[k-1]

#### k번째에 1,2,4번 타일을 배치한 경우
![image](https://github.com/user-attachments/assets/20f7c98b-bd90-4956-88d8-f5d750131dc2)
- array_124[k] = array_3[k-1] * 2 + array_124[k-1] * 3
- `array_3[k-1] * 2` (왼쪽 그림) : k-1번째에 3번 타일을 배치한 경우, k번째에 1, 4번 타일 배치 가능
- `array_124[k-1] * 3` (오른쪽 그림) : k-1번째에 1,2,4번 타일을 배치한 경우, k번째에 1,2,4번 타일 배치 가능

### tops[k]가 0인 경우
#### k번째에 3번 타일을 배치한 경우
![image](https://github.com/user-attachments/assets/92d9d54b-5b57-4fc5-9351-bf4a4496bd4b)
- array_3[k] = array_3[k-1] + array_124[k-1]

#### k번째에 2,4번 타일을 배치한 경우
![image](https://github.com/user-attachments/assets/68d2c123-cc3e-454f-8148-9b585ce01edd)
- array_124[k] = array_3[k-1] * 1 + array_124[k-1] * 2
- `array_3[k-1] * 1` (왼쪽 그림) : k-1번째에 3번 타일을 배치한 경우, k번째에 4번 타일 배치 가능
- `array_124[k-1] * 2` (오른쪽 그림) : k-1번째에 1,2,4번 타일을 배치한 경우, k번째에 2,4번 타일 배치 가능

## 참고
- 매 반복마다 나머지 계산을 하지 않는다면 시간초과