### PR TITLE
[다솔] 250303

### DIFF
--- a/Programmers/250303_산_모양_타일링/dbjoung.js
+++ b/Programmers/250303_산_모양_타일링/dbjoung.js
@@ -1,0 +1,22 @@
+function solution(n, tops) {
+  let all = tops.length + 2 * n + 1;
+  let real = tops.filter((num) => num == 1).length + 2 * n + 1;
+  let exist = 0;
+  let d = new Array(2 * 100000 + 2).fill(0);
+
+  d[1] = 1;
+  d[2] = 2;
+
+  for (let t = 3, exist = 3; t <= all; t++) {
+    const topExist = tops[Math.floor(t / 3) - 1];
+    if (t % 3 == 0 && topExist == 0) continue;
+
+    if (t % 3 == 1 && topExist == 1)
+      d[exist] = (d[exist - 1] + d[exist - 3]) % 10007;
+    else d[exist] = (d[exist - 1] + d[exist - 2]) % 10007;
+
+    exist++;
+  }
+
+  return d[real];
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #64 

## 조건
- 2n+1 개의 삼각형으로 만든 사다리꼴 슬롯에 삼각형 혹은 평행사변형 타일을 넣을 수 있는 경우의 수 구하기
- 사다리꼴 위에는 삼각형이 올라갈 수 있음.

## 풀이 방법
- 문제에서 준 n을 사용하지 않고, 작은 삼각형의 총 개수를 n으로 사용한다.
- 사다리꼴 위에 삼각형이 없을 경우, 점화식은 다음과 같다. 
+ d[n] = d[n-1]+d[n-2]
+ d[n-1]에 삼각형을 붙이는 경우와, d[n-2]에 평행사변형을 붙이는 경우의 수가 존재하기 때문이다.
- 위의 풀이 방법을, 사다리꼴 위에 삼각형이 있을 경우에 똑같이 적용해본다.
+ 오른쪽 기둥의 삼각형을 놓았을 때 사다리꼴 위에 삼각형이 올라가 있다면, d[n-1]에 삼각형을 붙이는 경우와 d[n-3]에 평행사변형을 붙이는 경우가 존재하게 된다.

## 정리
1. 총 타일 개수 구한다.
2. 타일 슬롯 개수 구한다(all). 실제 타일 개수 구한다(real).
3. 타일 슬롯 개수 만큼 반복문 돈다.
- if (타일 슬롯 인덱스 == 3의 배수) tops 배열 값 1이면 실테 타일 인덱스 ++, 아니면 continue;
- if (타일 슬롯 인덱스 == 3의 배수 +1 && tops 배열 값 == 1) d[n] = d[n-1] + d[n-3]
- else d[n] = d[n-1] + d[n-2];

## 시간복잡도
- tops.length + 2 * n(입력 n) + 1