### PR TITLE
[미라] 250305

### DIFF
--- a/Backjoon/250305_타임머신/ssum1ra.py
+++ b/Backjoon/250305_타임머신/ssum1ra.py
@@ -1,0 +1,36 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+def bf(start):
+    dist[start] = 0
+    for i in range(n):
+        for j in range(m):
+            start = edges[j][0]
+            end = edges[j][1]
+            time = edges[j][2]
+            if dist[start] != float('inf') and dist[start] + time < dist[end]:
+                dist[end] = dist[start] + time
+                if i == n - 1:
+                    return True 
+
+    return False
+
+n, m = map(int, input().split())
+edges = []
+dist = [float('inf')] * (n + 1)
+
+for _ in range(m):
+    start, end, time = map(int, input().split())
+    edges.append((start, end, time))
+
+negative_cycle = bf(1)
+
+if negative_cycle:
+    print(-1)
+else:
+    for i in range(2, n+1):
+        if dist[i] == float('inf'):
+            print(-1)
+        else:
+            print(dist[i])


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #70 

# 벨만 포드 알고리즘

1. 출발 노드를 설정한다.
2. 최단 거리 테이블을 초기화한다.
3. 다음의 과정을 (노드의 개수 - 1)번 반복한다.
  - 전체 간선을 하나씩 확인한다.
  - 각 간선을 거쳐 다른 노드로 가는 비용을 계산하여 최단거리 테이블을 갱신한다.

### 만약 음수 간선 순환이 발생하는지 체크하고 싶다면 3번의 과정을 한 번 더 수행한다.
  - 이때, 최단 거리 테이블이 갱신된다면 음수 간선 순환이 존재하는 것이다.

#### 이유
- 최단 경로는 최대 (노드의 개수 - 1)개의 간선만 포함한다.
  -  (노드의 개수 - 1)번 반복하면, 어떤 노드도 더 이상 최단 경로가 갱신되지 않음을 보장할 수 있다.

- 점진적인 갱신
  - 1번째 반복 → 출발점에서 1개의 간선만 사용한 최단 경로를 구한다.
  - 2번째 반복 → 최대 2개의 간선을 사용한 최단 경로를 구한다.
  - ...
  - (노드의 개수 - 1)번째 반복 → 최대 (노드의 개수 - 1)개의 간선을 사용한 최단 경로가 구해진다.

- 음수 사이클 검출 
  - 따라서, 만약 (노드의 개수 - 1)번을 초과하여 최단 거리가 계속 갱신된다면, 이는 음수 사이클이 존재함을 의미한다.

# 참고
## 출발점에서 다른 모든 노드까지의 최단 경로를 구하는 알고리즘
### bfs
- 가중치가 없는 경우

### 다익스트라 알고리즘
- 매번 방문하지 않은 노드 중에서 최단 거리가 가장 짧은 노드를 선택한다.
  - 어떤 경로에서 최단 거리를 이루는 전체 경로가 있다면, 그 경로의 부분 경로도 역시 최단 경로가 되어야 한다.
  - 즉, 시작점 → A → B가 최단 경로라면, 시작점 → A도 최단 경로여야 한다.
- 음수 간선이 없다면 최적의 해를 찾을 수 있다.

### 벨만 포드 알고리즘
- 매번 모든 간선을 전부 확인한다.
  - 따라서 다익스트라 알고리즘에서의 최적의 해를 항상 포함한다.
- 다익스트라 알고리즘에 비해서 시간이 오래 걸리지만 음수 간선 순환을 탐지할 수 있다.

### 플로이드-워셜 알고리즘
- 모든 노드 간의 최단 거리를 구하는 알고리즘