### PR TITLE
[태연] 250309

### DIFF
--- a/Programmers/250309_n+1_카드게임/rhino-ty.js
+++ b/Programmers/250309_n+1_카드게임/rhino-ty.js
@@ -1,0 +1,141 @@
+// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합 가능성이 있기 때문
+// DFS로 재귀적으로 전체 탐색 후 항상 최대 라운드 변수를 갱신하는 게 좋을 듯, 어차피 맨 아래 노드까지 내려갈 것이니
+
+// 1. 먼저 초기 변수 설정
+//   - 처음 시작카드 (n/3장)
+//   - 동전 할당 (coin개)
+//   - 목표 합 (n+1)
+//   - 최대 라운드
+// 2. DFS: 모든 경우의 수 탐색
+//   - 각 라운드마다 새로 뽑은 카드 2장에 대해 4가지 선택지
+//     - 두 카드 모두 X
+//     - 카드1만 가져가고 카드2 X (동전 1개)
+//     - 카드2만 가져가고 카드1 X (동전 1개)
+//     - 두 카드 모두 가져감 (동전 2개)
+// 3. 카드를 가져온 후 다음 라운드로 진행할 수 있는지 확인
+//   - 손에 든 카드 중 합이 n+1이 되는 두 장이 있는지 확인
+//     - 있으면: 해당 카드 두 장을 내고 다음 라운드로 진행
+//     - 없으면: 게임 종료, 현재 라운드 수를 최대값과 비교하여 갱신
+// 4. 모든 탐색이 끝나면 최대 라운드 수 반환
+
+// 가지치기 최적화
+// - 이미 찾은 최대 라운드보다 현재 라운드가 작고, 남은 카드가 부족하면 탐색 중단
+// - 동전을 다 써버리면 더 이상 카드를 가져올 수 없으므로 현재 카드만으로 가능한 최대 라운드 계산
+
+function solution(coin, cards) {
+  const n = cards.length;
+  const targetSum = n + 1;
+  let maxRound = 0;
+
+  // 처음 n/3장의 카드
+  const initialCards = cards.slice(0, n / 3);
+  // 남은 카드들
+  const remainingCards = cards.slice(n / 3);
+
+  // 합이 targetSum인 카드 두 장이 있는지 체크
+  function canMoveToNextRound(cards, targetSum) {
+    return findPairWithSum(cards, targetSum) !== null;
+  }
+
+  // 합이 targetSum인 카드 쌍 찾기
+  function findPairWithSum(cards, targetSum) {
+    for (let i = 0; i < cards.length; i++) {
+      for (let j = i + 1; j < cards.length; j++) {
+        if (cards[i] + cards[j] === targetSum) {
+          return [cards[i], cards[j]];
+        }
+      }
+    }
+    return null;
+  }
+
+  // DFS 탐색
+  function dfs(round, handCards, remainingCoins, nextCardIdx) {
+    // 이미 카드를 다 뽑았으면 현재 라운드로 최대값 갱신
+    if (nextCardIdx >= remainingCards.length) {
+      maxRound = Math.max(maxRound, round);
+      return;
+    }
+
+    // 이번 라운드에 뽑은 두 장의 카드
+    const card1 = remainingCards[nextCardIdx];
+    const card2 = remainingCards[nextCardIdx + 1];
+
+    // 현재 손패로 다음 라운드로 진행할 수 있는지 체크
+    const canProceedWithCurCards = canMoveToNextRound(handCards, targetSum);
+
+    // 케이스 1: 두 카드 모두 버리기
+    if (canProceedWithCurCards) {
+      // 다음 라운드로 진행 가능한 경우
+      const newHandCards = [...handCards];
+      const pairToUse = findPairWithSum(newHandCards, targetSum);
+      if (pairToUse) {
+        // 사용할 카드 두 장 제거
+        newHandCards.splice(newHandCards.indexOf(pairToUse[0]), 1);
+        newHandCards.splice(newHandCards.indexOf(pairToUse[1]), 1);
+        dfs(round + 1, newHandCards, remainingCoins, nextCardIdx + 2);
+      }
+    } else {
+      // 다음 라운드로 진행 불가능한 경우
+      maxRound = Math.max(maxRound, round);
+    }
+
+    // 남은 카드나 동전이 충분하지 않으면 더 이상 진행 불가
+    if (nextCardIdx + 2 >= remainingCards.length || round >= n / 2) {
+      return;
+    }
+
+    // 케이스 2: 카드1만 가져가기 (동전 1개 사용)
+    if (remainingCoins >= 1) {
+      const newHandCards = [...handCards, card1];
+      if (canMoveToNextRound(newHandCards, targetSum)) {
+        const pairToUse = findPairWithSum(newHandCards, targetSum);
+        if (pairToUse) {
+          const cardsAfterUsing = [...newHandCards];
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+          dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+        }
+      } else {
+        dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+      }
+    }
+
+    // 케이스 3: 카드2만 가져가기 (동전 1개 사용)
+    if (remainingCoins >= 1) {
+      const newHandCards = [...handCards, card2];
+      if (canMoveToNextRound(newHandCards, targetSum)) {
+        const pairToUse = findPairWithSum(newHandCards, targetSum);
+        if (pairToUse) {
+          const cardsAfterUsing = [...newHandCards];
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+          dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+        }
+      } else {
+        dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+      }
+    }
+
+    // 케이스 4: 두 카드 모두 가져가기 (동전 2개 사용)
+    if (remainingCoins >= 2) {
+      const newHandCards = [...handCards, card1, card2];
+      if (canMoveToNextRound(newHandCards, targetSum)) {
+        const pairToUse = findPairWithSum(newHandCards, targetSum);
+        if (pairToUse) {
+          const cardsAfterUsing = [...newHandCards];
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+          dfs(round + 1, cardsAfterUsing, remainingCoins - 2, nextCardIdx + 2);
+        }
+      } else {
+        dfs(round, newHandCards, remainingCoins - 2, nextCardIdx + 2);
+      }
+    }
+  }
+
+  // 초기 호출
+  dfs(1, initialCards, coin, 0);
+
+  return maxRound;
+}

--- a/Programmers/250309_n+1_카드게임/rhino-ty.js
+++ b/Programmers/250309_n+1_카드게임/rhino-ty.js
@@ -1,4 +1,4 @@
-// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합 가능성이 있기 때문
+// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합을 하는 것이 더 낫다는 가능성이 있기 때문
 // DFS로 재귀적으로 전체 탐색 후 항상 최대 라운드 변수를 갱신하는 게 좋을 듯, 어차피 맨 아래 노드까지 내려갈 것이니
 
 // 1. 먼저 초기 변수 설정
@@ -25,117 +25,85 @@
 function solution(coin, cards) {
   const n = cards.length;
   const targetSum = n + 1;
-  let maxRound = 0;
+  let round = 1; // 이미 1라운드부터 시작
 
-  // 처음 n/3장의 카드
-  const initialCards = cards.slice(0, n / 3);
-  // 남은 카드들
-  const remainingCards = cards.slice(n / 3);
+  const handCards = cards.slice(0, n / 3); // 처음에 가진 카드들 (a 배열)
+  const remainingDeck = cards.slice(n / 3); // 아직 뽑지 않은 카드들
+  const discardedCards = []; // 뽑았지만 아직 가져오지 않은 카드들 (b 배열)
+  let currentIdx = 0; // 현재 인덱스
 
-  // 합이 targetSum인 카드 두 장이 있는지 체크
-  function canMoveToNextRound(cards, targetSum) {
-    return findPairWithSum(cards, targetSum) !== null;
-  }
+  // 게임 시작
+  while (currentIdx < remainingDeck.length) {
+    // 이번 라운드에서 뽑은 두 장의 카드
+    const card1 = remainingDeck[currentIdx];
+    const card2 = remainingDeck[currentIdx + 1];
 
-  // 합이 targetSum인 카드 쌍 찾기
-  function findPairWithSum(cards, targetSum) {
-    for (let i = 0; i < cards.length; i++) {
-      for (let j = i + 1; j < cards.length; j++) {
-        if (cards[i] + cards[j] === targetSum) {
-          return [cards[i], cards[j]];
+    // 뽑은 카드를 discardedCards에 추가
+    discardedCards.push(card1, card2);
+
+    // 우선순위 1: 동전 0개 - 손에 든 카드 두 장으로 합이 n+1
+    let canProceed = false;
+    for (let i = 0; i < handCards.length; i++) {
+      for (let j = i + 1; j < handCards.length; j++) {
+        if (handCards[i] + handCards[j] === targetSum) {
+          // 다음 라운드로 진행 가능
+          handCards.splice(j, 1); // 인덱스가 큰 것부터 제거
+          handCards.splice(i, 1);
+          canProceed = true;
+          break;
         }
       }
-    }
-    return null;
-  }
-
-  // DFS 탐색
-  function dfs(round, handCards, remainingCoins, nextCardIdx) {
-    // 이미 카드를 다 뽑았으면 현재 라운드로 최대값 갱신
-    if (nextCardIdx >= remainingCards.length) {
-      maxRound = Math.max(maxRound, round);
-      return;
+      if (canProceed) break;
     }
 
-    // 이번 라운드에 뽑은 두 장의 카드
-    const card1 = remainingCards[nextCardIdx];
-    const card2 = remainingCards[nextCardIdx + 1];
-
-    // 현재 손패로 다음 라운드로 진행할 수 있는지 체크
-    const canProceedWithCurCards = canMoveToNextRound(handCards, targetSum);
-
-    // 케이스 1: 두 카드 모두 버리기
-    if (canProceedWithCurCards) {
-      // 다음 라운드로 진행 가능한 경우
-      const newHandCards = [...handCards];
-      const pairToUse = findPairWithSum(newHandCards, targetSum);
-      if (pairToUse) {
-        // 사용할 카드 두 장 제거
-        newHandCards.splice(newHandCards.indexOf(pairToUse[0]), 1);
-        newHandCards.splice(newHandCards.indexOf(pairToUse[1]), 1);
-        dfs(round + 1, newHandCards, remainingCoins, nextCardIdx + 2);
-      }
-    } else {
-      // 다음 라운드로 진행 불가능한 경우
-      maxRound = Math.max(maxRound, round);
-    }
-
-    // 남은 카드나 동전이 충분하지 않으면 더 이상 진행 불가
-    if (nextCardIdx + 2 >= remainingCards.length || round >= n / 2) {
-      return;
-    }
-
-    // 케이스 2: 카드1만 가져가기 (동전 1개 사용)
-    if (remainingCoins >= 1) {
-      const newHandCards = [...handCards, card1];
-      if (canMoveToNextRound(newHandCards, targetSum)) {
-        const pairToUse = findPairWithSum(newHandCards, targetSum);
-        if (pairToUse) {
-          const cardsAfterUsing = [...newHandCards];
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
-          dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+    // 우선순위 2: 동전 1개 - 손에 든 카드 1장 + 버린 카드 1장으로 합이 n+1
+    if (!canProceed && coin >= 1) {
+      for (let i = 0; i < handCards.length; i++) {
+        for (let j = 0; j < discardedCards.length; j++) {
+          if (handCards[i] + discardedCards[j] === targetSum) {
+            // 다음 라운드로 진행 가능
+            handCards.splice(i, 1);
+            discardedCards.splice(j, 1);
+            coin -= 1; // 동전 1개 사용
+            canProceed = true;
+            break;
+          }
         }
-      } else {
-        dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+        if (canProceed) break;
       }
     }
 
-    // 케이스 3: 카드2만 가져가기 (동전 1개 사용)
-    if (remainingCoins >= 1) {
-      const newHandCards = [...handCards, card2];
-      if (canMoveToNextRound(newHandCards, targetSum)) {
-        const pairToUse = findPairWithSum(newHandCards, targetSum);
-        if (pairToUse) {
-          const cardsAfterUsing = [...newHandCards];
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
-          dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+    // 우선순위 3: 동전 2개 - 버린 카드 두 장으로 합이 n+1
+    if (!canProceed && coin >= 2) {
+      for (let i = 0; i < discardedCards.length; i++) {
+        for (let j = i + 1; j < discardedCards.length; j++) {
+          if (discardedCards[i] + discardedCards[j] === targetSum) {
+            // 다음 라운드로 진행 가능
+            discardedCards.splice(j, 1);
+            discardedCards.splice(i, 1);
+            coin -= 2; // 동전 2개 사용
+            canProceed = true;
+            break;
+          }
         }
-      } else {
-        dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+        if (canProceed) break;
       }
     }
 
-    // 케이스 4: 두 카드 모두 가져가기 (동전 2개 사용)
-    if (remainingCoins >= 2) {
-      const newHandCards = [...handCards, card1, card2];
-      if (canMoveToNextRound(newHandCards, targetSum)) {
-        const pairToUse = findPairWithSum(newHandCards, targetSum);
-        if (pairToUse) {
-          const cardsAfterUsing = [...newHandCards];
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
-          cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
-          dfs(round + 1, cardsAfterUsing, remainingCoins - 2, nextCardIdx + 2);
-        }
-      } else {
-        dfs(round, newHandCards, remainingCoins - 2, nextCardIdx + 2);
-      }
+    // 다음 라운드로 진행할 수 없으면 게임 종료
+    if (!canProceed) {
+      return round;
+    }
+
+    // 다음 라운드로 진행
+    round++;
+    currentIdx += 2;
+
+    // 더 이상 뽑을 카드가 없으면 게임 종료
+    if (currentIdx >= remainingDeck.length) {
+      return round;
     }
   }
 
-  // 초기 호출
-  dfs(1, initialCards, coin, 0);
-
-  return maxRound;
+  return round;
 }

--- a/Programmers/250309_n+1_카드게임/rhino-ty.js
+++ b/Programmers/250309_n+1_카드게임/rhino-ty.js
@@ -1,27 +1,3 @@
-// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합을 하는 것이 더 낫다는 가능성이 있기 때문
-// DFS로 재귀적으로 전체 탐색 후 항상 최대 라운드 변수를 갱신하는 게 좋을 듯, 어차피 맨 아래 노드까지 내려갈 것이니
-
-// 1. 먼저 초기 변수 설정
-//   - 처음 시작카드 (n/3장)
-//   - 동전 할당 (coin개)
-//   - 목표 합 (n+1)
-//   - 최대 라운드
-// 2. DFS: 모든 경우의 수 탐색
-//   - 각 라운드마다 새로 뽑은 카드 2장에 대해 4가지 선택지
-//     - 두 카드 모두 X
-//     - 카드1만 가져가고 카드2 X (동전 1개)
-//     - 카드2만 가져가고 카드1 X (동전 1개)
-//     - 두 카드 모두 가져감 (동전 2개)
-// 3. 카드를 가져온 후 다음 라운드로 진행할 수 있는지 확인
-//   - 손에 든 카드 중 합이 n+1이 되는 두 장이 있는지 확인
-//     - 있으면: 해당 카드 두 장을 내고 다음 라운드로 진행
-//     - 없으면: 게임 종료, 현재 라운드 수를 최대값과 비교하여 갱신
-// 4. 모든 탐색이 끝나면 최대 라운드 수 반환
-
-// 가지치기 최적화
-// - 이미 찾은 최대 라운드보다 현재 라운드가 작고, 남은 카드가 부족하면 탐색 중단
-// - 동전을 다 써버리면 더 이상 카드를 가져올 수 없으므로 현재 카드만으로 가능한 최대 라운드 계산
-
 function solution(coin, cards) {
   const n = cards.length;
   const targetSum = n + 1;
@@ -107,3 +83,147 @@ function solution(coin, cards) {
 
   return round;
 }
+
+// DFS 풀이 -----------------------------------------------------------------------------------------------------------
+
+// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합을 하는 것이 더 낫다는 가능성이 있기 때문
+// DFS로 재귀적으로 전체 탐색 후 항상 최대 라운드 변수를 갱신하는 게 좋을 듯, 어차피 맨 아래 노드까지 내려갈 것이니
+
+// 1. 먼저 초기 변수 설정
+//   - 처음 시작카드 (n/3장)
+//   - 동전 할당 (coin개)
+//   - 목표 합 (n+1)
+//   - 최대 라운드
+// 2. DFS: 모든 경우의 수 탐색
+//   - 각 라운드마다 새로 뽑은 카드 2장에 대해 4가지 선택지
+//     - 두 카드 모두 X
+//     - 카드1만 가져가고 카드2 X (동전 1개)
+//     - 카드2만 가져가고 카드1 X (동전 1개)
+//     - 두 카드 모두 가져감 (동전 2개)
+// 3. 카드를 가져온 후 다음 라운드로 진행할 수 있는지 확인
+//   - 손에 든 카드 중 합이 n+1이 되는 두 장이 있는지 확인
+//     - 있으면: 해당 카드 두 장을 내고 다음 라운드로 진행
+//     - 없으면: 게임 종료, 현재 라운드 수를 최대값과 비교하여 갱신
+// 4. 모든 탐색이 끝나면 최대 라운드 수 반환
+
+// 가지치기 최적화
+// - 이미 찾은 최대 라운드보다 현재 라운드가 작고, 남은 카드가 부족하면 탐색 중단
+// - 동전을 다 써버리면 더 이상 카드를 가져올 수 없으므로 현재 카드만으로 가능한 최대 라운드 계산
+
+// function solution(coin, cards) {
+//   const n = cards.length;
+//   const targetSum = n + 1;
+//   let maxRound = 0;
+
+//   // 처음 n/3장의 카드
+//   const initialCards = cards.slice(0, n / 3);
+//   // 남은 카드들
+//   const remainingCards = cards.slice(n / 3);
+
+//   // 합이 targetSum인 카드 두 장이 있는지 체크
+//   function canMoveToNextRound(cards, targetSum) {
+//     return findPairWithSum(cards, targetSum) !== null;
+//   }
+
+//   // 합이 targetSum인 카드 쌍 찾기
+//   function findPairWithSum(cards, targetSum) {
+//     for (let i = 0; i < cards.length; i++) {
+//       for (let j = i + 1; j < cards.length; j++) {
+//         if (cards[i] + cards[j] === targetSum) {
+//           return [cards[i], cards[j]];
+//         }
+//       }
+//     }
+//     return null;
+//   }
+
+//   // DFS 탐색
+//   function dfs(round, handCards, remainingCoins, nextCardIdx) {
+//     // 이미 카드를 다 뽑았으면 현재 라운드로 최대값 갱신
+//     if (nextCardIdx >= remainingCards.length) {
+//       maxRound = Math.max(maxRound, round);
+//       return;
+//     }
+
+//     // 이번 라운드에 뽑은 두 장의 카드
+//     const card1 = remainingCards[nextCardIdx];
+//     const card2 = remainingCards[nextCardIdx + 1];
+
+//     // 현재 손패로 다음 라운드로 진행할 수 있는지 체크
+//     const canProceedWithCurCards = canMoveToNextRound(handCards, targetSum);
+
+//     // 케이스 1: 두 카드 모두 버리기
+//     if (canProceedWithCurCards) {
+//       // 다음 라운드로 진행 가능한 경우
+//       const newHandCards = [...handCards];
+//       const pairToUse = findPairWithSum(newHandCards, targetSum);
+//       if (pairToUse) {
+//         // 사용할 카드 두 장 제거
+//         newHandCards.splice(newHandCards.indexOf(pairToUse[0]), 1);
+//         newHandCards.splice(newHandCards.indexOf(pairToUse[1]), 1);
+//         dfs(round + 1, newHandCards, remainingCoins, nextCardIdx + 2);
+//       }
+//     } else {
+//       // 다음 라운드로 진행 불가능한 경우
+//       maxRound = Math.max(maxRound, round);
+//     }
+
+//     // 남은 카드나 동전이 충분하지 않으면 더 이상 진행 불가
+//     if (nextCardIdx + 2 >= remainingCards.length || round >= n / 2) {
+//       return;
+//     }
+
+//     // 케이스 2: 카드1만 가져가기 (동전 1개 사용)
+//     if (remainingCoins >= 1) {
+//       const newHandCards = [...handCards, card1];
+//       if (canMoveToNextRound(newHandCards, targetSum)) {
+//         const pairToUse = findPairWithSum(newHandCards, targetSum);
+//         if (pairToUse) {
+//           const cardsAfterUsing = [...newHandCards];
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+//           dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+//         }
+//       } else {
+//         dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+//       }
+//     }
+
+//     // 케이스 3: 카드2만 가져가기 (동전 1개 사용)
+//     if (remainingCoins >= 1) {
+//       const newHandCards = [...handCards, card2];
+//       if (canMoveToNextRound(newHandCards, targetSum)) {
+//         const pairToUse = findPairWithSum(newHandCards, targetSum);
+//         if (pairToUse) {
+//           const cardsAfterUsing = [...newHandCards];
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+//           dfs(round + 1, cardsAfterUsing, remainingCoins - 1, nextCardIdx + 2);
+//         }
+//       } else {
+//         dfs(round, newHandCards, remainingCoins - 1, nextCardIdx + 2);
+//       }
+//     }
+
+//     // 케이스 4: 두 카드 모두 가져가기 (동전 2개 사용)
+//     if (remainingCoins >= 2) {
+//       const newHandCards = [...handCards, card1, card2];
+//       if (canMoveToNextRound(newHandCards, targetSum)) {
+//         const pairToUse = findPairWithSum(newHandCards, targetSum);
+//         if (pairToUse) {
+//           const cardsAfterUsing = [...newHandCards];
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[0]), 1);
+//           cardsAfterUsing.splice(cardsAfterUsing.indexOf(pairToUse[1]), 1);
+//           dfs(round + 1, cardsAfterUsing, remainingCoins - 2, nextCardIdx + 2);
+//         }
+//       } else {
+//         dfs(round, newHandCards, remainingCoins - 2, nextCardIdx + 2);
+//       }
+//     }
+//   }
+
+//   // 초기 호출
+//   dfs(1, initialCards, coin, 0);
+
+//   return maxRound;
+// }


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #79

## 문제 분석 및 접근 방법 변화

### 초기 의사코드 작성과 접근 방법

이 문제를 처음 접했을 때, 핵심 특징을 분석하여 다음과 같은 의사코드를 작성했습니다.

```
// 각 cards마다 탐색 후 n+1이 있으면 뽑기? => 그리디한 방법은 안될 거 같음. 현재 카드보다 미래 카드와의 조합 가능성이 있기 때문
// DFS로 재귀적으로 전체 탐색 후 항상 최대 라운드 변수를 갱신하는 게 좋을 듯, 어차피 맨 아래 노드까지 내려갈 것이니
```

초기에는 각 카드를 뽑은 후 그리디한 방식으로 결정하는 것은 최적의 결과를 보장할 수 없다고 판단했습니다. 

그 이유는

1. **미래 카드와의 조합 가능성** : 현재 손에 든 카드를 미래에 뽑을 카드와 조합하면 더 많은 라운드를 진행할 가능성
2. **전체 경우의 수 탐색 필요** : 각 라운드마다 카드 선택에 대한 여러 경우의 수가 존재하며, 이들의 조합에 따라 결과가 달라짐
  - 현재 카드 내에서 13을 낼 수 있고, 현재 뽑은 카드를 먹거나 안먹어서 미래 카드와의 조합을 생각해야한다.

따라서 DFS(깊이 우선 탐색)를 통해 모든 가능한 경우의 수를 탐색하고, 완전 탐색을 통해 최대 라운드 수를 찾는 접근 방법을 선택했습니다.

### 처음 구현한 DFS 접근법 (첫 번째 코드: 8be108827146b0ff8da7619c70abeb644644834f)

DFS 방식으로 문제를 해결하기 위해 다음과 같은 단계적 접근을 구현했습니다.

```
1. 초기 변수 설정: 시작 카드(`n/3`장), 동전(`coin`개), 목표 합(`n+1`), 최대 라운드 변수
2. 각 라운드마다 4가지 선택지 탐색:
   - 두 카드 모두 버리기
   - 카드1만 가져가고 카드2는 버리기 (동전 1개 사용)
   - 카드2만 가져가고 카드1은 버리기 (동전 1개 사용)
   - 두 카드 모두 가져가기 (동전 2개 사용)
4. 각 선택 후 다음 라운드로 진행 가능한지 체크
   - 손에 든 카드 중 합이 n+1이 되는 두 장이 있는지 확인
   - 있으면 해당 카드를 내고 다음 라운드로 진행
   - 없으면 게임 종료, 최대 라운드 갱신
5. 효율성을 위한 가지치기 등 최적화 추가
```

이 방식의 핵심 아이디어는 **`모든 가능한 카드 선택의 조합을 탐색하여 최대 라운드 수를 찾자`**였습니다.

### DFS 접근법 한계 분석

DFS 접근법은 이론적으로 모든 경우의 수를 탐색하므로 최적의 결과를 보장할 수 있습니다. 하지만 다음과 같은 한계가 있었습니다.

1. **시간 복잡도**:  최악의 경우 O(4^(n/2))의 시간 복잡도를 가지며, n이 커질수록 계산 시간이 지수적으로 증가
2. **메모리 사용** : 재귀 호출과 상태 복사로 인한 메모리 소비가 큼
3. **불필요한 탐색** : 많은 경우의 수가 최적해에 도달하지 못하는 경로임에도 탐색을 진행

### 그리디 접근법으로의 전환

안풀려서 [카카오 해설](https://tech.kakao.com/posts/610)을 결국 봐버렸습니다. 추가 분석을 통해 이 문제는 실제로 그리디한 접근법으로 최적의 해를 찾을 수 있음을 깨달았습니다..

```
문제에서 설명하는 게임에서는 각 라운드에 카드 뭉치에서 카드 두 장을 뽑을 때마다 동전을 소모해 카드를 가지거나 동전을 소모하지 않고 카드를 버릴지 선택해야 합니다. 
하지만, 실제 문제를 코드로 해결하는 과정에서는, 현재 라운드까지 뽑은 카드들을 기억해 뒀다가 필요할 때마다 동전을 소모해 카드를 가져오는 방식으로 구현해도 됩니다.
```

1. `a` 배열: 손에 든 카드들
2. `b` 배열: 뽑았지만 아직 가져오지 않은 카드들(동전으로 가져올 수 있는 카드들)
3. 우선순위에 따라 최소한의 동전을 사용하는 방식이 최적의 해를 보장함

### 최종 그리디 접근법 (현재 코드: 508768183355a2437e51eb6b84cca4bd053fc23a)

해설을 바탕으로, 다음과 같은 우선순위 기반 그리디 접근법을 구현했습니다.

1. 우선순위 1 : 동전 0개 소모 - 손에 든 카드 두 장(`a`에서만)으로 합이 n+1
2. 우선순위 2 : 동전 1개 소모 - 손에 든 카드 1장(`a`)과 버린 카드 1장(`b`)으로 합이 n+1
3. 우선순위 3 : 동전 2개 소모 - 버린 카드 두 장(`b`에서만)으로 합이 n+1

이 우선순위를 따라 항상 최소의 동전을 사용하도록 구현함으로써, 더 많은 라운드를 진행할 수 있게 되었습니다.

## 성능 분석

### DFS 접근법 (첫 번째 코드)
- 시간 복잡도: O(4^(n/2)) - 각 라운드마다 4가지 선택을 고려
- 공간 복잡도: O(n) - 재귀 호출 스택과 카드 배열 저장에 필요한 공간
- 장점: 모든 가능한 경우를 탐색하여 이론적으로 최적해 보장
- 단점: n이 큰 경우 시간 초과 발생 가능, 비효율적인 탐색 경로 포함

### 그리디 접근법 (현재 코드)
- 시간 복잡도: O(n²) - 각 라운드마다 카드 쌍 탐색을 위한 중첩 반복문
- 공간 복잡도: O(n) - 카드 배열 저장에 필요한 공간
- 장점: 훨씬 효율적인 시간 복잡도, 명확한 우선순위에 따른 간결한 로직
- 특징: 이 문제에서는 그리디 접근법이 최적해 보장


### 왜 그리디 접근법이 최적해를 보장하는가?

처음 직관적으로 생각했을 때, 현재 카드를 버리고 미래 카드와의 더 좋은 조합을 기다리는 것이 더 많은 라운드를 진행할 수 있을 것 같아 보였습니다.

하지만, 이 문제에서 그리디 접근법이 최적해를 보장하는 핵심적인 이유는 **동전의 가치**와 **목표(최대 라운드 수)의 직접적인 관계** 때문입니다.

1. **동전은 한정된 자원** : 게임에서 동전은 재생 불가능한 자원. 각 동전은 정확히 한 장의 카드를 가져오는 데 사용.
2. **목표는 최대 라운드 수** : 문제 목표는 가능한 한 많은 라운드를 진행.
3. **각 라운드의 진행 조건이 동일** : 모든 라운드에서 합이 n+1인 카드 두 장 내야함. 이 조건은 변하지 않음.

이런 상황에서 **최소한의 동전으로 각 라운드를 진행하는 것**이 전체적으로 가장 많은 라운드를 진행할 수 있는 방법이 됩니다.

- 동전 0개 사용 > 동전 1개 사용 > 동전 2개 사용

이렇게 현재 상황에서 동전을 그냥 **"적게"** 사용하는 것만으로도 최대 라운드를 가져갈 수 있습니다.

### 내가 생각한 가정에 대한 반론

#### **가정 1**: "현재 카드 내에서 13을 낼 수 있고, 현재 뽑은 카드를 먹거나 안먹어서 미래 카드와의 조합을 생각했어야한다."

한 라운드에서 동전을 아끼는 것(현재 카드만으로 13을 만드는 것)은 미래 라운드에서 사용할 수 있는 동전을 더 많이 확보하는 것과 같습니다. 동전은 라운드를 진행하기 위한 직접적인 자원이기 때문에, **최대한 적은 동전을 사용하는 것이 항상 더 유리**합니다.

#### **가정 2**: "현재 뽑은 카드와 현재 핸드에 있는 카드만 생각하면 최적해가 나오지 않는다"

이 게임에서 동전을 사용한 후에 얻을 수 있는 이득은 오직 '라운드 진행'입니다. 미래에 더 좋은 카드 조합이 나온다 해도, 그 조합을 위해 현재 동전을 아끼는 것보다는 현재 가능한 최소한의 동전으로 라운드를 진행하는 것이 항상 더 많은 라운드를 보장합니다.

#### 상황 예시

현재 상황은 아래와 같습니다.

- 손에 든 카드로 13을 만들 수 있다(동전 0개 사용)
- 또는 뽑은 카드를 한 장 가져와서 13을 만들 수 있다(동전 1개 사용)

후자를 선택하는 것이 최적일 수 있을까요? 그렇지 않습니다.

- 동전 0개 사용: 현재 라운드 진행 + 동전 1개 저장 → 미래에 최대 1개 라운드 추가 가능
- 동전 1개 사용: 현재 라운드 진행 → 추가 라운드 없음

이래서 항상 최소 동전을 사용하는 전략이 최대 라운드를 보장합니다.