### PR TITLE
[태연] 250310

### DIFF
--- a/Programmers/250310_봉인된_주문/rhino-ty.js
+++ b/Programmers/250310_봉인된_주문/rhino-ty.js
@@ -1,0 +1,47 @@
+// 기본적인 구현 문제이라고 생각함
+// 문자열 직접 생산 + 전체 탐색은 n과 bans의 길이가 너무 길어서 당연히 제외
+// 그렇다면 n 이하의 문자열에 해당되는 bans 수 만큼 추가한 n 값을 추출 후
+// 패턴에 의거해 문자열을 생산하면 될 거 같음
+// 추가) 알파벳 개수는 26개, JS에서는 15자리 정수까지 변수로 사용할 수 있기 때문에 BigInt 안써도 됨
+
+// 1. n번째 문자열을 찾기 전에 해당 문자열의 길이 결정 필요
+//   - 각 길이별 문자열 개수 계산하고 범위 체크
+//   - 길이 1: 26개(a-z), 길이 2: 26*26개, 길이 3: 26*26*26개...
+//   - 누적합을 이용해서 n이 어느 길이 구간에 속하는지 파악
+// 2. ban 리스트 처리하기
+//   - bans 문자열 중에서 우리가 찾을 n번째 문자열보다 사전상 앞에 있는 것들 개수 세기
+//   - 즉, ban된 문자열 때문에 건너뛰어야 하는 개수만큼 n 값 증가시키기
+// 3. 최종 n번째 문자열 생성
+//   - n이 속한 길이에서 몇 번째인지 계산
+//   - 해당 순서를 알파벳 인덱스로 변환해서 문자열 조합
+
+function orderToSpell(n) {
+  let result = '';
+  while (n > 0) {
+    n -= 1;
+    result = String.fromCharCode((n % 26) + 'a'.charCodeAt(0)) + result;
+    n = Math.floor(n / 26);
+  }
+  return result || 'a'; // 결과가 빈 문자열인 경우 "a" 반환
+}
+
+function solution(n, bans) {
+  // sort()는 길이를 따지지 않고, 맨 앞부터 유니코드를 따져서 조건이 필요함
+  // bans 정렬 (길이 순, 같은 길이면 사전 순)
+  const bansSorted = [...bans].sort((a, b) => {
+    if (a.length !== b.length) return a.length - b.length;
+    return a.localeCompare(b);
+  });
+
+  for (const ban of bansSorted) {
+    const spell = orderToSpell(n);
+    if (ban.length > spell.length) {
+      break;
+    }
+    if (ban.length < spell.length || ban <= spell) {
+      n += 1;
+    }
+  }
+
+  return orderToSpell(n);
+}


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #83 

### 문제 요약

- 알파벳 소문자로 구성된 문자열이 다음 규칙에 따라 정렬됨
  1. 글자 수가 적은 주문부터 먼저 기록
  2. 글자 수가 같다면 사전 순서로 기록
- 특정 문자열들(bans)이 삭제된 후, n번째 문자열을 찾아야 함

### 접근 방법
1. 직접 n개의 문자열을 생성하는 것은 n이 최대 10^15까지 가능하므로 불가능
2. 특정 숫자를 문자열로 변환하는 방식(26진법 변환)과 금지된 문자열 처리를 조합

### 초기 의사코드와 개선
처음에는 다음과 같은 의사코드를 계획했습니다.
```
// 1. n번째 문자열의 길이 결정
//   - 각 길이별 문자열 개수 계산하고 범위 체크
//   - 누적합으로 n이 어느 길이 구간에 속하는지 파악
// 2. ban 리스트 처리하기
//   - n번째 문자열보다 사전상 앞에 있는 ban 문자열 개수 세기
//   - 해당 개수만큼 n 값 증가시키기
// 3. 최종 n번째 문자열 생성
//   - n이 속한 길이에서 몇 번째인지 계산
//   - 해당 순서를 알파벳으로 변환
```

#### **왜 초기 의사코드 방식이 효율적이지 않았는가**
- `ban` 목록에서 "n번째 문자열보다 사전상 앞에 있는 것들 개수 세기"가 복잡함
- 각 ban에 대해 정확한 순서 계산이 필요한데, 이를 위한 추가 로직이 복잡해짐
- 직관적으로 코드를 구현하기 어려움

#### **개선된 접근법**
- n번째 문자열을 직접 계산하고, 각 ban과 비교하는 방식으로 단순화
- 더 직관적이고 구현이 간결해짐

### 현재 알고리즘 설명
1. `orderToSpell` 함수를 통해 숫자를 26진법 문자열로 변환
2. 금지된 문자열(bans)을 길이순, 사전순으로 정렬
3. 각 금지된 문자열을 순회하며:
   - 현재 n값에 해당하는 문자열 계산
   - 금지된 문자열이 현재 문자열보다 더 길다면 영향 없음(순회 종료)
   - 금지된 문자열이 현재 문자열보다 사전순으로 앞서거나 짧다면 n 증가
4. 최종 조정된 n에 해당하는 문자열 반환

### 복잡도 분석
- 시간 복잡도
  - 정렬: O(b log b) (b는 bans의 길이)
  - 전체 순회: O(b * L) (L은 결과 문자열의 최대 길이)
- 공간 복잡도: O(b + L)

### 핵심 아이디어
- 직접적인 문자열 생성 대신 순서를 계산하는 방식 사용
- 문자열 변환 함수(orderToSpell)를 통해 n번째 문자열 직접 계산
- 금지된 문자열이 현재 위치에 영향을 미치는지 효율적으로 판단

