### PR TITLE
[다솔] 250311

### DIFF
--- a/Programmers/250311_완전범죄/dbjoung.js
+++ b/Programmers/250311_완전범죄/dbjoung.js
@@ -1,0 +1,27 @@
+function solution(info, n, m) {
+  const d = new Array(info.length + 1)
+    .fill(null)
+    .map(() => new Array(m).fill(Infinity));
+
+  d[0][0] = 0;
+  for (let i = 1; i <= info.length; i++) {
+    for (let b = 0; b < m; b++) {
+      if (d[i - 1][b] < 121) {
+        if (d[i - 1][b] + info[i - 1][0] < n)
+          d[i][b] = Math.min(d[i - 1][b] + info[i - 1][0], d[i][b]);
+        if (b + info[i - 1][1] < m)
+          d[i][b + info[i - 1][1]] = Math.min(
+            d[i - 1][b],
+            d[i][b + info[i - 1][1]]
+          );
+      }
+    }
+  }
+
+  const result = d[info.length].reduce((f, s) => {
+    return f > s ? s : f;
+  }, Infinity);
+
+  if (result == Infinity) return -1;
+  else return result;
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #87 

### 점화식 도출
- d[i][B의 누적 흔적 수] = A의 누적 흔적 수
- 1번째 물건을 훔쳤을 때, 2번째 물건을 훔쳤을 때, 3번째... .., ~, i번째 물건을 훔쳤을 때 까지 순회하면서 b의 누적 흔적 수에 따른 a의 누적 흔적 수를 기록한다.

- d[i-1][b] 의 다음 단계는 아래 두 가지 경우로 나뉜다.
	- i번째 물건을 A가 훔치는 경우 : d[i][b] = d[i-1][b]+info[i][0]
		- A가 훔쳤으므로 점화식의 해만 업데이트.
	- i번째 물건을 B가 훔치는 경우 : d[i][b+info[i][1]] = d[i-1][b]
		- B가 훔쳤으므로 두 번째 인덱스만 업데이트
- 단, A는 n 이상의, B는 m 이상의 흔적을 남기면 안되므로, 해당 조건을 만족시킬 경우에만 d[i][x]를 업데이트해준다.
- B가 훔치는 경우는 두 번째 인덱스를 업데이트하므로, 이후 b 배열을 순회할 때 중복 업데이트가 될 수 있다. 따라서 Math.min 메소드로 가장 최소값을 유지하도록 한다.