### PR TITLE
[태연] 250314

### DIFF
--- a/Programmers/250314_충돌위험_찾기/rhino-ty.js
+++ b/Programmers/250314_충돌위험_찾기/rhino-ty.js
@@ -1,3 +1,163 @@
+// 해쉬 계열 사용 최적화
+
+function solution(points, routes) {
+  // Map을 사용해 포인트 번호 -> 좌표 매핑, 0-indexing
+  const pointToCoord = new Map();
+  for (let i = 0; i < points.length; i++) {
+    pointToCoord.set(i + 1, points[i]);
+  }
+
+  // 시간별 좌표에 위치한 로봇 집합을 저장하는 Map
+  // Map<시간, Map<좌표키, Set<로봇ID>>>
+  const timeToCoordRobots = new Map();
+
+  // 각 로봇의 경로 시뮬레이션
+  for (let robotIdx = 0; robotIdx < routes.length; robotIdx++) {
+    const route = routes[robotIdx];
+    let curTime = 0;
+
+    // 시작 위치 처리
+    const startPointNum = route[0];
+    const [startR, startC] = pointToCoord.get(startPointNum);
+    addRobotPosition(0, [startR, startC], robotIdx);
+
+    // 경로 계산
+    for (let i = 0; i < route.length - 1; i++) {
+      const currentPointNum = route[i];
+      const nextPointNum = route[i + 1];
+
+      const [currentR, currentC] = pointToCoord.get(currentPointNum);
+      const [nextR, nextC] = pointToCoord.get(nextPointNum);
+
+      // r 좌표 이동
+      let r = currentR;
+      while (r !== nextR) {
+        r += r < nextR ? 1 : -1;
+        curTime++;
+        addRobotPosition(curTime, [r, currentC], robotIdx);
+      }
+
+      // c 좌표 이동
+      let c = currentC;
+      while (c !== nextC) {
+        c += c < nextC ? 1 : -1;
+        curTime++;
+        addRobotPosition(curTime, [r, c], robotIdx);
+      }
+    }
+  }
+
+  function addRobotPosition(time, coord, robotIdx) {
+    const coordKey = coord.join(','); // 여전히 문자열 키 사용 (성능 이유)
+
+    if (!timeToCoordRobots.has(time)) {
+      timeToCoordRobots.set(time, new Map());
+    }
+
+    const coordMap = timeToCoordRobots.get(time);
+
+    if (!coordMap.has(coordKey)) {
+      coordMap.set(coordKey, new Set());
+    }
+
+    coordMap.get(coordKey).add(robotIdx);
+  }
+
+  // 위험 상황 집계
+  let dangerCount = 0;
+
+  // 각 시간별로 충돌 체크
+  timeToCoordRobots.forEach((coordMap) => {
+    coordMap.forEach((robotSet) => {
+      if (robotSet.size >= 2) {
+        dangerCount++;
+      }
+    });
+  });
+
+  return dangerCount;
+}
+
+// function solution(points, routes) {
+//   // 1-indexed 매핑 생성
+//   const pointToCoord = {};
+//   for (let i = 0; i < points.length; i++) {
+//     pointToCoord[i + 1] = points[i];
+//   }
+
+//   // 시간별 각 좌표에 위치한 로봇 수를 바로 기록하는 맵
+//   // { 시간: { 좌표키: 로봇 수 } }
+//   const timeToCoordCount = {};
+
+//   // 각 로봇의 경로 시뮬레이션 및 시간별 위치 맵에 바로 추가
+//   for (let robotIdx = 0; robotIdx < routes.length; robotIdx++) {
+//     const route = routes[robotIdx];
+//     let curTime = 0;
+
+//     // 시작 위치 처리 (시간 0)
+//     const startPointNum = route[0];
+//     const [startR, startC] = pointToCoord[startPointNum];
+//     addRobotPosition(0, [startR, startC]);
+
+//     // 경로상의 각 연속된 포인트 쌍에 대해 이동 경로 계산
+//     for (let i = 0; i < route.length - 1; i++) {
+//       const currentPointNum = route[i];
+//       const nextPointNum = route[i + 1];
+
+//       const [currentR, currentC] = pointToCoord[currentPointNum];
+//       const [nextR, nextC] = pointToCoord[nextPointNum];
+
+//       // r 좌표 이동
+//       let r = currentR;
+//       while (r !== nextR) {
+//         r += r < nextR ? 1 : -1;
+//         curTime++;
+//         addRobotPosition(curTime, [r, currentC]);
+//       }
+
+//       // c 좌표 이동
+//       let c = currentC;
+//       while (c !== nextC) {
+//         c += c < nextC ? 1 : -1;
+//         curTime++;
+//         addRobotPosition(curTime, [r, c]);
+//       }
+//     }
+//   }
+
+//   // 로봇의 위치를 시간별 객체에 추가하는 함수
+//   function addRobotPosition(time, coord) {
+//     const coordKey = coord.join(',');
+
+//     if (!timeToCoordCount[time]) {
+//       timeToCoordCount[time] = {};
+//     }
+
+//     if (!timeToCoordCount[time][coordKey]) {
+//       timeToCoordCount[time][coordKey] = 0;
+//     }
+
+//     timeToCoordCount[time][coordKey]++;
+//   }
+
+//   // 위험 상황(충돌 가능성) 집계
+//   let dangerCount = 0;
+
+//   // 각 시간별로 좌표에 2대 이상 로봇이 있는 경우 카운트
+//   for (const time in timeToCoordCount) {
+//     const coordCounts = timeToCoordCount[time];
+
+//     for (const coordKey in coordCounts) {
+//       if (coordCounts[coordKey] >= 2) {
+//         dangerCount++;
+//       }
+//     }
+//   }
+
+//   return dangerCount;
+// }
+
+// ----------------------------------------------------------------------------------------------------------------
 // 각각의 이동, 충돌 확인을 포함한 과정을 말해야함 => 그냥 시뮬레이션 문제인 듯
 // 입력값도 작아서 3차원 반복문도 괜찮을 듯?
 
@@ -14,95 +174,95 @@
 //    - 각 시간대에서 로봇 수가 2 이상인 좌표의 개수 합산
 // 4. 총 충돌 위험 횟수 반환
 
-function solution(points, routes) {
-  // 포인트 번호 -> 좌표 매핑, 1-indexed
-  const pointToCoord = {};
-  for (let i = 0; i < points.length; i++) {
-    pointToCoord[i + 1] = points[i];
-  }
+// function solution(points, routes) {
+//   // 포인트 번호 -> 좌표 매핑, 1-indexed
+//   const pointToCoord = {};
+//   for (let i = 0; i < points.length; i++) {
+//     pointToCoord[i + 1] = points[i];
+//   }
 
-  // 각 로봇의 시간별 위치 기록 배열
-  const robotPositions = [];
+//   // 각 로봇의 시간별 위치 기록 배열
+//   const robotPositions = [];
 
-  // 각 로봇마다 경로 계산
-  for (let robotIdx = 0; robotIdx < routes.length; robotIdx++) {
-    const route = routes[robotIdx];
-    const positions = []; // 해당 로봇의 시간별 위치
+//   // 각 로봇마다 경로 계산
+//   for (let robotIdx = 0; robotIdx < routes.length; robotIdx++) {
+//     const route = routes[robotIdx];
+//     const positions = []; // 해당 로봇의 시간별 위치
 
-    let curTime = 0;
+//     let curTime = 0;
 
-    // 시작 위치 추가 (시간 0)
-    const startPointNum = route[0];
-    const [startR, startC] = pointToCoord[startPointNum];
-    positions.push({ time: 0, coord: [startR, startC] });
+//     // 시작 위치 추가 (시간 0)
+//     const startPointNum = route[0];
+//     const [startR, startC] = pointToCoord[startPointNum];
+//     positions.push({ time: 0, coord: [startR, startC] });
 
-    // 경로의 각 포인트를 순회
-    for (let i = 0; i < route.length - 1; i++) {
-      const currentPointNum = route[i];
-      const nextPointNum = route[i + 1];
+//     // 경로의 각 포인트를 순회
+//     for (let i = 0; i < route.length - 1; i++) {
+//       const currentPointNum = route[i];
+//       const nextPointNum = route[i + 1];
 
-      const [currentR, currentC] = pointToCoord[currentPointNum];
-      const [nextR, nextC] = pointToCoord[nextPointNum];
+//       const [currentR, currentC] = pointToCoord[currentPointNum];
+//       const [nextR, nextC] = pointToCoord[nextPointNum];
 
-      // r 좌표 조정
-      let r = currentR;
-      while (r !== nextR) {
-        r += r < nextR ? 1 : -1;
-        curTime++;
-        positions.push({ time: curTime, coord: [r, currentC] });
-      }
+//       // r 좌표 조정
+//       let r = currentR;
+//       while (r !== nextR) {
+//         r += r < nextR ? 1 : -1;
+//         curTime++;
+//         positions.push({ time: curTime, coord: [r, currentC] });
+//       }
 
-      // c 좌표 조정
-      let c = currentC;
-      while (c !== nextC) {
-        c += c < nextC ? 1 : -1;
-        curTime++;
-        positions.push({ time: curTime, coord: [r, c] });
-      }
-    }
+//       // c 좌표 조정
+//       let c = currentC;
+//       while (c !== nextC) {
+//         c += c < nextC ? 1 : -1;
+//         curTime++;
+//         positions.push({ time: curTime, coord: [r, c] });
+//       }
+//     }
 
-    robotPositions.push(positions);
-  }
+//     robotPositions.push(positions);
+//   }
 
-  let dangerCount = 0;
+//   let dangerCount = 0;
 
-  // 최대 시간 찾기
-  // 모든 로봇이 마지막 경로 지점에 도착하는 시간 중 가장 늦은 시간까지만 체크하면 됨
-  let maxTime = 0;
-  for (const positions of robotPositions) {
-    if (positions.length > 0) {
-      maxTime = Math.max(maxTime, positions[positions.length - 1].time);
-    }
-  }
+//   // 최대 시간 찾기
+//   // 모든 로봇이 마지막 경로 지점에 도착하는 시간 중 가장 늦은 시간까지만 체크하면 됨
+//   let maxTime = 0;
+//   for (const positions of robotPositions) {
+//     if (positions.length > 0) {
+//       maxTime = Math.max(maxTime, positions[positions.length - 1].time);
+//     }
+//   }
 
-  // 각 시간대별로 충돌 체크
-  for (let time = 0; time <= maxTime; time++) {
-    // 좌표 -> 로봇 수 매핑
-    const coordToRobots = {};
+//   // 각 시간대별로 충돌 체크
+//   for (let time = 0; time <= maxTime; time++) {
+//     // 좌표 -> 로봇 수 매핑
+//     const coordToRobots = {};
 
-    // 각 로봇의 해당 시간 위치 확인
-    for (let robotIdx = 0; robotIdx < robotPositions.length; robotIdx++) {
-      const positions = robotPositions[robotIdx];
+//     // 각 로봇의 해당 시간 위치 확인
+//     for (let robotIdx = 0; robotIdx < robotPositions.length; robotIdx++) {
+//       const positions = robotPositions[robotIdx];
 
-      // 해당 시간에 로봇이 어디에 있는지 찾기
-      const position = positions.find((pos) => pos.time === time);
+//       // 해당 시간에 로봇이 어디에 있는지 찾기
+//       const position = positions.find((pos) => pos.time === time);
 
-      if (position) {
-        const coordKey = position.coord.join(',');
-        if (!coordToRobots[coordKey]) {
-          coordToRobots[coordKey] = [];
-        }
-        coordToRobots[coordKey].push(robotIdx);
-      }
-    }
+//       if (position) {
+//         const coordKey = position.coord.join(',');
+//         if (!coordToRobots[coordKey]) {
+//           coordToRobots[coordKey] = [];
+//         }
+//         coordToRobots[coordKey].push(robotIdx);
+//       }
+//     }
 
-    // 위험 상황 카운트 (같은 좌표에 2대 이상의 로봇이 있는 경우)
-    for (const coordKey in coordToRobots) {
-      if (coordToRobots[coordKey].length >= 2) {
-        dangerCount++;
-      }
-    }
-  }
+//     // 위험 상황 카운트 (같은 좌표에 2대 이상의 로봇이 있는 경우)
+//     for (const coordKey in coordToRobots) {
+//       if (coordToRobots[coordKey].length >= 2) {
+//         dangerCount++;
+//       }
+//     }
+//   }
 
-  return dangerCount;
-}
+//   return dangerCount;
+// }

--- a/Programmers/250314_충돌위험_찾기/rhino-ty.js
+++ b/Programmers/250314_충돌위험_찾기/rhino-ty.js
@@ -1,0 +1,108 @@
+// 각각의 이동, 충돌 확인을 포함한 과정을 말해야함 => 그냥 시뮬레이션 문제인 듯
+// 입력값도 작아서 3차원 반복문도 괜찮을 듯?
+
+// 1. 포인트 정보를 좌표(r, c)로 매핑할 맵 생성 (포인트 번호 -> 좌표) => indexing이 0인지, 1인지 주의
+// 2. 각 로봇의 이동 경로 계산
+//    - 각 로봇마다 시간대별 위치를 저장할 배열 생성
+//    - 각 로봇의 경로 순회하기
+//      a. 현재 포인트에서 다음 포인트까지의 최단 경로 계산 => 두 포인트 사이의 최단 경로는 맨해튼 거리
+//      b. 최단 경로 이동 시 r 좌표 먼저 조정 후 c 좌표 조정 => 주의!!  "r 좌표가 변하는 이동을 c 좌표가 변하는 이동보다 먼저 합니다."
+//      c. 경로상의 모든 중간 좌표와 시간 기록
+// 3. 충돌 체크
+//    - 각 시간대별로 맵 생성 (좌표 -> 로봇 수)
+//    - 모든 로봇의 위치를 시간별로 순회하면서 맵에 카운트 기록
+//    - 각 시간대에서 로봇 수가 2 이상인 좌표의 개수 합산
+// 4. 총 충돌 위험 횟수 반환
+
+function solution(points, routes) {
+  // 포인트 번호 -> 좌표 매핑, 1-indexed
+  const pointToCoord = {};
+  for (let i = 0; i < points.length; i++) {
+    pointToCoord[i + 1] = points[i];
+  }
+
+  // 각 로봇의 시간별 위치 기록 배열
+  const robotPositions = [];
+
+  // 각 로봇마다 경로 계산
+  for (let robotIdx = 0; robotIdx < routes.length; robotIdx++) {
+    const route = routes[robotIdx];
+    const positions = []; // 해당 로봇의 시간별 위치
+
+    let curTime = 0;
+
+    // 시작 위치 추가 (시간 0)
+    const startPointNum = route[0];
+    const [startR, startC] = pointToCoord[startPointNum];
+    positions.push({ time: 0, coord: [startR, startC] });
+
+    // 경로의 각 포인트를 순회
+    for (let i = 0; i < route.length - 1; i++) {
+      const currentPointNum = route[i];
+      const nextPointNum = route[i + 1];
+
+      const [currentR, currentC] = pointToCoord[currentPointNum];
+      const [nextR, nextC] = pointToCoord[nextPointNum];
+
+      // r 좌표 조정
+      let r = currentR;
+      while (r !== nextR) {
+        r += r < nextR ? 1 : -1;
+        curTime++;
+        positions.push({ time: curTime, coord: [r, currentC] });
+      }
+
+      // c 좌표 조정
+      let c = currentC;
+      while (c !== nextC) {
+        c += c < nextC ? 1 : -1;
+        curTime++;
+        positions.push({ time: curTime, coord: [r, c] });
+      }
+    }
+
+    robotPositions.push(positions);
+  }
+
+  let dangerCount = 0;
+
+  // 최대 시간 찾기
+  // 모든 로봇이 마지막 경로 지점에 도착하는 시간 중 가장 늦은 시간까지만 체크하면 됨
+  let maxTime = 0;
+  for (const positions of robotPositions) {
+    if (positions.length > 0) {
+      maxTime = Math.max(maxTime, positions[positions.length - 1].time);
+    }
+  }
+
+  // 각 시간대별로 충돌 체크
+  for (let time = 0; time <= maxTime; time++) {
+    // 좌표 -> 로봇 수 매핑
+    const coordToRobots = {};
+
+    // 각 로봇의 해당 시간 위치 확인
+    for (let robotIdx = 0; robotIdx < robotPositions.length; robotIdx++) {
+      const positions = robotPositions[robotIdx];
+
+      // 해당 시간에 로봇이 어디에 있는지 찾기
+      const position = positions.find((pos) => pos.time === time);
+
+      if (position) {
+        const coordKey = position.coord.join(',');
+        if (!coordToRobots[coordKey]) {
+          coordToRobots[coordKey] = [];
+        }
+        coordToRobots[coordKey].push(robotIdx);
+      }
+    }
+
+    // 위험 상황 카운트 (같은 좌표에 2대 이상의 로봇이 있는 경우)
+    for (const coordKey in coordToRobots) {
+      if (coordToRobots[coordKey].length >= 2) {
+        dangerCount++;
+      }
+    }
+  }
+
+  return dangerCount;
+}


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

### 문제 분석 및 접근 방법

이 문제는 시뮬레이션 문제로, 여러 로봇이 각자의 경로를 따라 이동할 때 발생하는 충돌 위험 상황을 카운트해야 합니다. 처음에는 직관적인 접근법으로 시작했으나, 대규모 테스트 케이스에서 시간 초과가 발생했습니다.

### 초기 접근법 및 시간 복잡도 분석

처음 작성한 코드는 아래와 같은 단계로 동작했습니다.

1. 각 로봇의 전체 경로와 시간별 위치를 모두 먼저 계산해 `robotPositions` 배열에 저장
2. 각 시간대마다 모든 로봇의 위치 배열을 순회하면서 검색(`find`)해 현재 시간의 위치를 찾고, 충돌 카운트

이 접근법의 시간 복잡도는 아래와 같다고 생각했습니다.

- 경로 계산: O(R × P × D)
  - R: 로봇 수
  - P: 포인트 수
  - D: 포인트 간 거리
- 충돌 체크: O(T × R × L)
  - T: 총 시간
  - C: 각 시간대에 로봇이 존재하는 좌표 수 (R보단 적거나 같음)

테스트 결과, 14-20번 테스트에서 시간 초과가 발생했는데, 이는 `find` 메서드를 사용한 위치 검색 과정(O(L) 시간 소요)이 반복되면서 발생한 성능 병목 현상이 발생했습니다. 
그래서, `find` 메서드 제거하는 방법을 고안해냈습니다.

### 최적화 접근법

#### 주요 최적화 전략

1. **중간 저장 단계 제거**: 로봇 위치를 모두 계산 후 충돌을 검사하는 대신, 위치 계산과 동시에 맵에 직접 기록
   - 기존: 위치 계산 → 저장 → 검색 → 카운트
   - 최적화: 위치 계산 → 맵에 직접 기록 → 카운트

2. **자료구조 변경**: 단순 배열 대신 해시 기반 자료구조 사용
   - `Map`과 `Set`을 활용해 O(1) 시간에 검색 가능하도록 개선
   - 기존: 시간별 검색에 O(L) 소요
   - 최적화: 시간별 검색에 O(1) 소요

3. **로봇 식별을 통한 중복 카운트 방지**: 단순히 로봇 수를 세는 대신 로봇 ID를 `Set`에 저장해 정확한 카운팅

특히, 1번 중간 저장 단계를 제거 하는 것이 킥이었습니다.

1. **중간 데이터 구조 변경**
   - 기존: 각 로봇별로 위치 배열 저장 → 나중에 검색
   - 리팩토링: 시간별 좌표에 로봇 수를 직접 카운트하는 맵 사용
2. **`find` 메서드 제거**
   - 기존: 각 시간마다 로봇의 위치를 `find` 메서드로 검색 (O(L) 시간)
   - 리팩토링: 위치를 계산하는 즉시 해당 시간과 좌표에 로봇 수를 증가 (O(1) 시간)
3. **중첩 루프 구조 변경**
   - 기존: 로봇 계산 → 시간별 충돌 체크 (2단계)
   - 리팩토링: 로봇 이동 계산과 동시에 위치 맵에 바로 기록 (1단계)

#### 최적화 코드 시간 복잡도

- 기존 코드: O(R × P × D) + O(T × R × L)
  - R: 로봇 수, P: 포인트 수, D: 포인트 간 거리
- 최적화 코드: O(R × P × D) + O(T × C)
  - T: 총 시간, C: 각 시간대에 로봇이 존재하는 좌표 수

### 자료구조 선택 이유

1. **`Map` 선택 이유**
   - 빈번한 검색과 추가 작업에 O(1) 시간 복잡도 제공
   - 키가 숫자(시간)인 경우 객체보다 더 효율적인 메모리 사용
   - 순서 보장이 필요한 시간별 처리에 적합

2. **`Set` 선택 이유**
   - 각 좌표에 위치한 로봇들의 중복 없는 컬렉션 관리에 최적
   - 크기 확인(size 프로퍼티)으로 2대 이상 로봇 존재 여부를 O(1)에 확인 가능
   - 일반 배열에서 중복 체크하려면 O(n) 시간이 소요되는 것과 비교하여 효율적

### 결론

구현 - 시뮬레이션 문제는 데이터를 어떤 구조로 효율적으로 관리하느냐가 성능에 큰 영향을 미칩니다..