### PR TITLE
[태연] 250321

### DIFF
--- a/Programmers/250321_수식_복원하기/rhino-ty.js
+++ b/Programmers/250321_수식_복원하기/rhino-ty.js
@@ -1,0 +1,93 @@
+// 1. expressions 배열을 순회, 진법 후보군(2~9진법)을 사용해 진법 추출
+//    - 각 수식마다 'A 연산자 B = C' 형태로 파싱
+//    - X가 아닌 C값이 있는 수식들 나중에 분석
+//      - 각 진법(2~9)에서 A와 B를 계산했을 때 C와 일치하는지 확인 => parseInt(51, 8) 이런 식으로 하면 되나?
+//      - 일치하는 진법들만 후보군에 유지
+// 2. 후보 진법들 중에서 모든 수식을 만족하는 진법 찾기
+//    - 만약 여러 진법이 가능하다면 모두 저장 => 혹시 모를 `?`를 쓰기 위해
+// 3. 결과 배열 생성
+//    - X가 포함된 수식들 추출
+//      - 가능한 진법이 하나라면 계산된 결과값으로 대체
+//      - 가능한 진법이 여러 개이고 결과값이 모두 같다면 그 값으로 대체
+//      - 가능한 진법이 여러 개이고 결과값이 다르다면 "?"로 대체
+// 4. 완성된 결과 배열 반환
+
+function solution(expressions) {
+  // 결과 배열
+  const result = [];
+
+  // X가 있는 수식들의 인덱스 찾기
+  const xIndices = expressions.reduce((acc, exp, idx) => {
+    if (exp.includes('= X')) acc.push(idx);
+    return acc;
+  }, []);
+
+  // 가능한 진법 찾기 (2~9 진법)
+  let possibleBases = [2, 3, 4, 5, 6, 7, 8, 9];
+
+  // X가 아닌 수식들을 통해 가능한 진법 필터링
+  for (let i = 0; i < expressions.length; i++) {
+    if (!expressions[i].includes('= X')) {
+      // 수식 파싱
+      const [left, right] = expressions[i].split(' = ');
+      const [a, op, b] = left.split(' ');
+      const c = right;
+
+      // 현재 가능한 진법 중에서 이 수식을 만족하는 진법만 필터링
+      possibleBases = possibleBases.filter((base) => {
+        const numA = parseInt(a, base);
+        const numB = parseInt(b, base);
+        const numC = parseInt(c, base);
+
+        // 계산 결과가 맞는지 확인
+        if (op === '+') {
+          return numA + numB === numC;
+        } else {
+          // op === '-'
+          return numA - numB === numC;
+        }
+      });
+    }
+  }
+
+  // X가 있는 수식들에 대해 결과값 계산
+  for (const idx of xIndices) {
+    const [left, right] = expressions[idx].split(' = ');
+    const [a, op, b] = left.split(' ');
+
+    // 각 가능한 진법에서의 결과값 계산
+    const results = new Set();
+    const valuesByBase = new Map();
+
+    for (const base of possibleBases) {
+      const numA = parseInt(a, base);
+      const numB = parseInt(b, base);
+
+      let calculatedResult;
+      if (op === '+') {
+        calculatedResult = numA + numB;
+      } else {
+        // op === '-'
+        calculatedResult = numA - numB;
+      }
+
+      // 계산 결과를 해당 진법의 문자열로 변환
+      const resultInBase = calculatedResult.toString(base);
+      results.add(resultInBase);
+
+      if (!valuesByBase.has(resultInBase)) {
+        valuesByBase.set(resultInBase, []);
+      }
+      valuesByBase.get(resultInBase).push(base);
+    }
+
+    // 결과값이 모든 가능한 진법에서 동일하면 그 값을, 아니면 '?'
+    if (results.size === 1) {
+      result.push(expressions[idx].replace('X', [...results][0]));
+    } else {
+      result.push(expressions[idx].replace('X', '?'));
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #130 

### 문제 해결 과정

이 문제는 덧셈/뺄셈 수식들을 분석해 고대 문명의 진법을 파악하고, 지워진 결과값들을 채워 넣는 작업입니다. 

#### 1. 진법의 이해와 접근법 설계

초기에는 수식을 파싱하고 진법을 찾는 기본적인 접근법을 구상했습니다. `parseInt('51', 8) - parseInt('5', 8)`와 같은 방식으로 다양한 진법에서 숫자를 변환하고 계산할 수 있다는 통찰에서 시작했습니다.

#### 2. 첫 번째 구현과 시행착오

첫 구현에서는 X가 없는 수식들을 통해 가능한 진법을 필터링하고, 이를 기반으로 X가 있는 수식들의 결과값을 계산했습니다. 그러나 테스트 케이스 4와 5에서 모든 결과가 `?`로 나오는 문제가 발생했습니다.

#### 3. 문제점 분석

핵심 문제점들을 발견했습니다.

- **숫자 유효성 검사 부재**: 각 진법에서 사용 가능한 숫자를 사전에 필터링 X
- **진법 추론 로직 불충분**: 예를 들어, 숫자 '7'이 등장한다면 최소 8진법 이상이어야 한다는 중요한 제약을 고려하지 않음

#### 4. 개선된 접근법

개선된a 해결책은 두 가지 핵심 단계로 구성됐습니다.

1. **사전 진법 필터링**: 모든 수식에서 가장 큰 숫자(digit)를 찾아 이보다 큰 진법만 고려하도록 제한. 예를 들어 숫자 '7'이 있다면 최소 8진법 이상만 고려.
2. **결과값 매핑을 위한 Map 사용**: 각 결과값이 어떤 진법들에서 나오는지 Map을 통해 효율적으로 추적. 이를 통해 모든 진법에서 결과가 동일한지 또는 다른지 쉽게 판별 가능.

#### 5. Map 자료구조의 활용

`Map`을 사용해 결과값과 진법 간의 관계를 관리해줬습니다.

- 결과값을 키로, 해당 결과가 나온 진법 목록을 값으로 저장
- `resultsByBase.size === 1`로 모든 진법에서 결과가 동일한지 확인
- 결과가 다양할 경우 '?'를 사용하는 로직을 명확하게 구현

### 최종 솔루션

최종 코드는 아래와 같은 과정으로 진법을 찾고 결과값을 계산합니다.

1. 모든 수식에서 사용된 가장 큰 숫자(`digit`)를 찾아 가능한 진법을 제한
2. X가 없는 수식들을 분석하여 진법을 추가로 필터링
3. 가능한 진법들에서 X가 있는 수식들의 결과를 계산
4. 모든 진법에서 결과가 동일하면 그 값을, 아니면 '?'를 반환