### PR TITLE
[태연] 250326

### DIFF
--- a/Programmers/250326_미로_탈출_명령어/rhino-ty.js
+++ b/Programmers/250326_미로_탈출_명령어/rhino-ty.js
@@ -1,0 +1,63 @@
+// 총 이동 거리가 k
+// 같은 격자를 여러 번 방문해도 됨
+// 가능한 경로 중 사전순으로 가장 빠른 경로를 찾아야 함 => d, l, r, u 순으로 탐색하면 될 듯?
+//   => DFS 속 그리디 느낌. 사전 순으로 방향을 모두 탐색하면 자동으로 사전 순 result가 쌓여짐
+// (최단 거리 - k)의 차이가 홀수면 impossible 반환 (왕복이 짝수 단위로만 가능하기 때문) => 3번을 보면 알 수 있음
+// 첫 시작이 d가 있으면 lru 시작 폐기, 2번째 시작이 d가 있으면 lru 폐기 이런 식으로 가지치기를 할 수도 있을 듯
+
+function solution(n, m, x, y, r, c, k) {
+  // 최단거리 계산: 점과 점사이
+  const totalMinDist = getMinDist(x, y, r, c);
+  // 불가능한 경우 체크: 최단거리가 k보다 크거나 그 차이가 홀수
+  if (totalMinDist > k || (k - totalMinDist) % 2 !== 0) return 'impossible';
+
+  // 사전순 방향
+  const directions = [
+    ['d', 1, 0],
+    ['l', 0, -1],
+    ['r', 0, 1],
+    ['u', -1, 0],
+  ];
+
+  let result = '';
+
+  function dfs(curX, curY, remainingMoves, path) {
+    // 결과를 찾았을 때, dfs 함수가 진행되고 있는 것도 있으니 끝내기 => 가지치기
+    if (result !== '') return;
+
+    // 남은 이동 횟수로 목적지에 도달할 수 없는 경우 체크
+    const distToTarget = getMinDist(curX, curY, r, c);
+    if (distToTarget > remainingMoves || (remainingMoves - distToTarget) % 2 !== 0) {
+      return;
+    }
+
+    // 목적지에 도달하고 남은 이동이 0이면 경로 저장
+    if (curX === r && curY === c && remainingMoves === 0) {
+      result = path;
+      return;
+    }
+
+    // 남은 이동이 없으면 종료
+    if (remainingMoves === 0) return;
+
+    // 사전순으로 이동 시도 (d, l, r, u)
+    for (const [dir, dx, dy] of directions) {
+      const nextX = curX + dx;
+      const nextY = curY + dy;
+
+      // 격자 내에 있는지 확인, 재귀 설정
+      if (nextX >= 1 && nextX <= n && nextY >= 1 && nextY <= m) {
+        dfs(nextX, nextY, remainingMoves - 1, path + dir);
+      }
+    }
+  }
+
+  dfs(x, y, k, '');
+
+  return result === '' ? 'impossible' : result;
+}
+
+// 점과 점사이 최솟값 구하기
+function getMinDist(cx, cy, r, c) {
+  return Math.abs(cx - r) + Math.abs(cy - c);
+}


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #143

### 문제 분석

이 문제는 n x m 격자 미로에서 (x, y)에서 출발해 (r, c)로 정확히 k번 이동하여 탈출하는 문제입니다. 같은 격자를 여러 번 방문할 수 있고, 사전순으로 가장 빠른 경로를 찾아야 합니다.

#### 핵심 조건

- 격자 바깥으로 나갈 수 없음
- 총 이동 거리가 정확히 k여야 함
- 같은 격자를 여러 번 방문 가능
- 사전순으로 가장 빠른 경로 찾기 (d, l, r, u)

### 해결 과정

#### 1. 기본적인 접근 방식 설계
처음에는 최단 경로를 찾는 BFS가 적합하다고 생각했지만, 정확히 k번 이동해야 하고 사전순으로 가장 빠른 경로를 찾아야 하므로 DFS를 사용하기로 결정했습니다.

#### 2. 불가능한 경우 사전 필터링
코드를 작성하기 전에 논리적으로 불가능한 경우를 먼저 필터링하여 효율성을 높였습니다:
- 최단 거리가 k보다 크면 절대 도달할 수 없으므로 "impossible"
- (k - 최단 거리)가 홀수면 도달 불가능 (왕복은 항상 짝수 단위로만 가능)

#### 3. 사전순 탐색 방식 구현
사전순으로 가장 빠른 경로를 찾기 위해 DFS 탐색 순서를 'dlru' 순으로 설정했습니다. 이렇게 하면 처음 찾은 유효한 경로가 자동으로 사전순으로 가장 빠른 경로가 됩니다.

#### 4. 가지치기 최적화
다음과 같은 가지치기를 통해 불필요한 탐색을 줄였습니다.

- 결과를 이미 찾은 경우 더 이상 탐색하지 않음
- 현재 위치에서 목적지까지의 거리와 남은 이동 횟수를 비교하여 불가능한 경우 탐색 중단
- (남은 이동 - 목적지까지 거리)가 홀수인 경우 불가능하므로 탐색 중단

### 코드 구현 과정

#### 1. **최단 거리 계산 함수 구현**
 맨해튼 거리를 사용하여 두 점 사이의 최단 거리를 계산하는 함수를 만들었습니다.

#### 2. **방향 정의**
 사전순으로 빠른 `'dlru'` 순서로 방향을 정의했습니다. 처음에는 2차원 배열에 튜플로 저장했고, 각 튜플에는 방향 문자와 x, y 변위값을 포함했습니다.

#### 3. **DFS 함수 구현**

- 현재 위치, 남은 이동 횟수, 현재까지 경로를 매개변수로 사용
- 기저 조건: 목적지에 도달하고 남은 이동이 0이면 경로 저장
- 가지치기: 결과를 이미 찾았거나, 도달 불가능한 경우 탐색 중단
- 사전순으로 방향 탐색

#### 4. **Edge Case 처리**

 여러 테스트 케이스를 통해 코드를 검증하고, 특히 출발지와 목적지가 같은 경우, 최소 이동 거리보다 k가 작은 경우 등의 예외 상황을 처리했습니다.

### 시간 복잡도 분석

최악의 경우 시간 복잡도는 O(4^k)이지만, 가지치기 최적화를 통해 실제 실행 시간은 크게 감소하게 됩니다. 사전순으로 탐색하므로 첫 번째 유효한 경로를 찾으면 즉시 종료되어 효율적입니다.