### PR TITLE
[태연] 250331

### DIFF
--- a/Programmers/250331_순위_검색/rhino-ty.js
+++ b/Programmers/250331_순위_검색/rhino-ty.js
@@ -1,0 +1,85 @@
+// 그냥 구현하면 정확도는 100점: info를 순회하면서, info 분해, 또 query 순회하면서 분해 후 info 순회하면서 개수 탐색
+// 하지만 O(infoN * queryN) = 최악의 경우 5,000,000,000번의 연산을 하게 되니 효율성 필요
+// info 분해 시 그룹화 진행(해당되는 조건) 및 점수 이진탐색? => 점수는 무조건 있어야해서 따로 둠
+
+function solution(info, query) {
+  // 해시맵 생성
+  const infoMap = {};
+
+  // info 정보 처리
+  info.forEach((i) => {
+    const [lang, job, exp, food, score] = i.split(' ');
+    const scoreNum = parseInt(score);
+
+    // 가능한 모든 조합 생성
+    getCombinations(lang, job, exp, food).forEach((key) => {
+      if (!infoMap[key]) {
+        infoMap[key] = [];
+      }
+      infoMap[key].push(scoreNum);
+    });
+  });
+
+  // 점수 정렬
+  for (const key in infoMap) {
+    infoMap[key].sort((a, b) => a - b);
+  }
+
+  // 쿼리 처리
+  return query.map((q) => {
+    const parts = q.split(' and ');
+    const [food, score] = parts.pop().split(' ');
+    const key = parts.concat(food).join('');
+    const scoreNum = parseInt(score);
+
+    if (!infoMap[key]) return 0;
+
+    return infoMap[key].length - binarySearch(infoMap[key], scoreNum);
+  });
+}
+
+// 모든 조합 생성 함수: DFS 방식
+function getCombinations(lang, job, exp, food) {
+  const result = [];
+  const options = [
+    [lang, '-'],
+    [job, '-'],
+    [exp, '-'],
+    [food, '-'],
+  ];
+
+  function generate(index, current) {
+    // 기저
+    if (index === 4) {
+      result.push(current.join(''));
+      return;
+    }
+
+    options[index].forEach((option) => {
+      current[index] = option;
+      generate(index + 1, current);
+    });
+  }
+
+  generate(0, Array(4).fill(''));
+  return result;
+}
+
+// 이진 탐색 함수
+function binarySearch(arr, target) {
+  let left = 0;
+  let right = arr.length;
+
+  while (left < right) {
+    const mid = Math.floor((left + right) / 2);
+    if (arr[mid] >= target) {
+      right = mid;
+    } else {
+      left = mid + 1;
+    }
+  }
+
+  return left;
+}
+
+// 데이터베이스 시스템도 이와 매우 유사한 방식으로 작동한다! 실제로 데이터베이스에서는 이런 기법을 훨씬 더 정교하게 활용하기는 하지만..


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #155

### 문제 해결 과정

#### 처음 접근
처음에는 단순 구현으로 접근했습니다. 모든 `info`를 순회하면서 `info` 분해, 또 `query` 순회하면서 분해 후 info를 다시 순회하며 개수를 세는 방식입니다. 

이 방식은 정확성 테스트는 통과할 수 있지만, 시간 복잡도가 O(infoN * queryN) => 최악의 경우 5,000,000,000번의 연산이 필요해 효율성 테스트를 통과하지 못합니다.

#### 최적화 접근

효율성을 높이기 위해 해시맵을 이용한 전처리 기법(인덱싱)을 활용했습니다. 

### 구체적 해결 과정

#### 1단계: 데이터 인덱싱
각 지원자 정보에 대해 가능한 모든 조합($2^4$ = 총 16가지)을 생성하여 해시맵(객체)에 저장했습니다. 예를 들어 `"java backend junior pizza 150"`의 경우:
- "javabackendjuniorpizza" → [150]
- "javabackendjunior-" → [150]
- "javabackend-pizza" → [150]
- ... (총 16가지 조합)

이 과정은 `'getCombinations'` 함수를 통해 DFS 방식으로 모든 조합을 생성합니다.

#### 2단계: 점수 정렬
모든 정보를 해시맵에 저장한 후, 각 조합에 해당하는 점수 배열을 정렬했습니다. 이후 이진 탐색을 사용하기 위한 전처리 단계입니다.

#### 3단계: 쿼리 처리
각 쿼리에 대해,

1. 쿼리 문자열을 분석하여 적절한 키 형태로 변환
2. 해당 키에 맞는 점수 배열을 찾음
3. 이진 탐색을 통해 요구 점수 이상인 지원자 수를 효율적으로 계산

예를 들어, `"java and backend and junior and pizza 100"` 쿼리의 경우,

- 키: `"javabackendjuniorpizza"`
- 점수 조건: 100 이상
- 이진 탐색을 통해 [150] 배열에서 100 이상인 값의 개수를 찾음 → 1명

### 시간 복잡도 개선
- 전처리: O(N * 2^4 * log(N)) - 각 지원자마다 16가지 조합을 처리하고 정렬
- 쿼리 처리: O(M * log(N)) - 각 쿼리마다 이진 탐색으로 처리

이렇게 공간-시간 트레이드오프 전략(공간을 더 활용해 시간 단축)을 활용해 추가 메모리를 사용하는 대신 쿼리 처리 시간을 크게 단축했습니다.

>[!TIP]
> 문제 요구사항에서 봤을 때, 알아차릴 수 있겠지만 `query` 등 DB에서 쓰는 단어를 많이 썼습니다.
> 즉, DB 시스템에서도 많이 활용되는 인덱싱 기법을 통해 DB 탐색 방법을 유사하게 나마 구현하는 문제였습니다.
> 실제 검색 시스템이나 DB의 핵심 최적화 전략과 유사하게 작동합니다.

\+ 서점에서 색인 같은 거를 초기화 해준 다음 책 찾는 거랑 비슷하네