### PR TITLE
[태연] 250401

### DIFF
--- a/Programmers/250401_교점에_별_만들기/rhino-ty.js
+++ b/Programmers/250401_교점에_별_만들기/rhino-ty.js
@@ -1,0 +1,78 @@
+// 구현 문제, 각 직선을 조합으로 구하고, 교점 공식으로 정수가 나오는 것들을 저장, 나오는 result로 교점 그리기(최소 사각형)
+
+function solution(line) {
+  const points = new Set(); // 중복 제거를 위함
+  const combinations = getCombination(line);
+
+  // 모든 조합에 대해 교점 계산
+  for (let i = 0; i < combinations.length; i++) {
+    const [line1, line2] = combinations[i];
+    const [A, B, E] = line1;
+    const [C, D, F] = line2;
+
+    // 분모가 0인 경우 (평행 또는 일치) 제외
+    const denominator = A * D - B * C;
+    if (denominator === 0) continue;
+
+    // 교점 계산
+    const x = (B * F - E * D) / denominator;
+    const y = (E * C - A * F) / denominator;
+
+    // 정수 좌표인 경우만 저장
+    // if (x % 1 === 0 && y % 1 === 0) {
+    if (Number.isInteger(x) && Number.isInteger(y)) {
+      points.add(`${x},${y}`); // Set 중복 제거는 메모리주소에 의해 제거됨(참조형은 안돼서 문자열로 치환)
+    }
+  }
+
+  const pointArray = [...points].map((p) => {
+    const [x, y] = p.split(',').map(Number);
+    return [x, y];
+  });
+
+  let minX = Infinity,
+    minY = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity;
+  for (const [x, y] of pointArray) {
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const result = Array(height)
+    .fill()
+    .map(() => Array(width).fill('.'));
+
+  for (const [x, y] of pointArray) {
+    // 좌표계 변환
+    const row = maxY - y; // y축 뒤집기
+    const col = x - minX;
+    result[row][col] = '*';
+  }
+
+  return result.map((row) => row.join(''));
+}
+
+function getCombination(lineArr) {
+  const lineCombi = [];
+
+  function dfs(current, start) {
+    if (current.length === 2) {
+      lineCombi.push([...current]);
+      return;
+    }
+
+    for (let i = start; i < lineArr.length; i++) {
+      current.push(lineArr[i]);
+      dfs(current, i + 1);
+      current.pop();
+    }
+  }
+
+  dfs([], 0);
+  return lineCombi;
+}


### PR DESCRIPTION
## 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #159 

### 문제 분석

- 여러 개의 직선 ($Ax + By + C = 0$) 형태가 주어졌을 때, 각 직선 쌍의 교점 중 정수 좌표에 있는 점들을 별로 표시해야 함
- 별이 그려진 최소 사각형을 출력해야 함

### 접근 방법
1. **모든 직선 쌍에 대해 교점 구하기**: 모든 직선 조합을 구해 각 조합마다 교점을 계산
2. **정수 좌표 필터링**: 교점 중 x, y 좌표가 모두 정수인 점만 선택
3. **최소 사각형 찾기**: 모든 정수 교점을 포함하는 최소 크기의 사각형 테두리 계산
4. **별 그리기**: 최소 사각형 안에 정수 교점 위치에 별 표시

### 구현 세부 사항



1. **직선 간 교점 계산**
   - 두 직선의 교점 공식 활용
    ```
     x = (B₁C₂ - B₂C₁) / (A₁B₂ - A₂B₁)
     y = (A₂C₁ - A₁C₂) / (A₁B₂ - A₂B₁)
     ```
   - 분모가 0인 경우(평행 또는 일치) 건너뜀

2. **정수 좌표 검사**
   - `Number.isInteger()`를 사용해 x, y 좌표가 모두 정수인지 검사

3. **성능 최적화**
   - 별도의 조합 배열을 만들지 않고 이중 반복문으로 직접 모든 쌍 처리
   - 중복 교점 방지를 위해 `Set` 자료구조 활용

4. **좌표계 변환**
   - 수학적 좌표계와 배열 인덱스 사이의 차이를 고려하여 y축 뒤집기
   - `row = maxY - y`를 통해 좌표계 변환

### 시간 복잡도 & 공간 복잡도
- 시간 복잡도
  - 직선 개수를 n이라고 할 때, 모든 직선 쌍을 검사하므로 O(n²)
  - 별을 그리는 과정은 O(k)로, k는 정수 교점의 수
- 공간 복잡도
  - 교점을 저장하는 Set, 결과 배열 등을 고려하면 O(k)로, k는 정수 교점의 수

### 핵심 포인트
- 기하학적 문제를 배열 인덱스로 매핑할 때 좌표계 변환에 주의
- 불필요한 중간 배열 생성을 줄여 성능 최적화
- 정수 판별 시 명확한 함수(Number.isInteger) 사용

