### PR TITLE
[다솔] 250404

### DIFF
--- a/Programmers/250404_광고_삽입/dbjoung.js
+++ b/Programmers/250404_광고_삽입/dbjoung.js
@@ -1,0 +1,54 @@
+function transToSec(time) {
+  const [h, m, s] = time.split(":").map(Number);
+  return h * 3600 + m * 60 + s;
+}
+
+function transToTime(sec) {
+  const h = Math.floor(sec / 3600);
+  let least = sec - h * 3600;
+  const m = Math.floor(least / 60);
+  least -= m * 60;
+
+  return [
+    `${h}`.padStart(2, 0),
+    `${m}`.padStart(2, 0),
+    `${least}`.padStart(2, 0),
+  ].join(":");
+}
+
+function solution(play_time, adv_time, logs) {
+  const playSec = transToSec(play_time);
+  const advSec = transToSec(adv_time);
+  const check = new Array(playSec + 1).fill(0);
+
+  for (const log of logs) {
+    const [start, end] = log.split("-");
+    const startTime = transToSec(start);
+    const endTime = transToSec(end);
+    check[startTime]++;
+    check[endTime]--;
+  }
+
+  for (let i = 1; i < check.length; i++) {
+    check[i] += check[i - 1];
+  }
+
+  let start = 0;
+  let end = 0;
+  let sum = 0;
+
+  let longestSec = 0;
+  let longestCheck = 0;
+  while (end <= check.length) {
+    if (end - start == advSec) {
+      if (longestSec < sum) {
+        longestSec = sum;
+        longestCheck = start;
+      }
+      sum -= check[start++];
+    }
+    sum += check[end++];
+  }
+
+  return transToTime(longestCheck);
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #168 

## 풀이 시간
- 의미 없음

## 풀이 방법
- 단순하게 풀면 시간복잡도 초과.
- 누적합으로 풀어야 한다.

0. 배열에 저장하기 쉽게 시분초를 only 초로 변환한다. 
1. log를 순회하며 startTime 인덱스에는 +1을, endTime 인덱스에는 -1을 한다.
2. 그리고 d[i]+=d[i-1] 점화식으로 누적합을 구하면, 해당 타임에 총 몇 개 구간이 겹쳐있는 지 계산 가능하다.
3. 이후 투포인터 사용해서 광고 시간 구간 중 가장 합이 큰 구간을 찾는다.
4. 주의할 점. endTime은 구간에 포함되지 않음....


## 시간복잡도
- X