### PR TITLE
[태연] 250414

### DIFF
--- a/Baekjoon/250415_부분합/rhino-ty.js
+++ b/Baekjoon/250415_부분합/rhino-ty.js
@@ -1,0 +1,35 @@
+// 연속된 부분합 중 최소 => 구간이 고정된 슬라이딩 윈도우는 아님, 투포인터를 사용해야할 듯
+// 1. 시작/끝 인덱스(0), 현재 합(0), 최소 길이(무한대) 초기화
+// 2. end가 배열이랑 길이가 같을 때까지 반복
+//   - end를 증가하고 현재합에 더하기
+//   - end로 지나온 인덱스를 while로 순회: S가 현재합보다 초과면(빼야하니까)
+//     - start, 현재합, 최소 길이 변경
+// 3. 최소 길이가 아직도 Infinity면 0, 아니면 그대로 반환
+
+function getMinSumS(N, S, numArr) {
+  let start = 0;
+  let end = 0;
+  let curSum = 0;
+  let minLength = Infinity;
+
+  while (end <= numArr.length - 1) {
+    curSum += numArr[end];
+
+    while (curSum >= S) {
+      minLength = Math.min(minLength, end - start + 1);
+
+      curSum -= numArr[start];
+      start++;
+    }
+
+    end++;
+  }
+
+  return minLength === Infinity ? 0 : minLength;
+}
+
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().trim().split('\n');
+const [N, S] = input[0].split(' ').map(Number);
+const numArr = input[1].split(' ').map(Number);
+console.log(getMinSumS(N, S, numArr));

--- a/Baekjoon/250415_부분합/rhino-ty.js
+++ b/Baekjoon/250415_부분합/rhino-ty.js
@@ -12,7 +12,7 @@ function getMinSumS(N, S, numArr) {
   let curSum = 0;
   let minLength = Infinity;
 
-  while (end <= numArr.length - 1) {
+  while (end <= N) {
     curSum += numArr[end];
 
     while (curSum >= S) {


### PR DESCRIPTION
# 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #190 

## 문제 접근 방법 & 풀이 과정
이 문제는 연속된 수들의 부분합 중 그 합이 S 이상이 되는 것 중 가장 짧은 것의 길이를 구하는 과제였습니다. 처음에는 모든 부분 배열을 탐색하는 O(N²) 방식을 생각했지만, 실행 시간이 0.5초라 투포인터 알고리즘을 활용해 O(N) 시간 복잡도로 최적화하도록 결정했습니다.

### 투포인터 알고리즘

- 두 개의 포인터(`start`, `end`)를 활용해 연속된 부분 배열을 효율적으로 탐색
- 시작/끝 포인터가 0부터 시작해, 증가 및 감소 하면서 조건에 맞는 구간을 찾아감

#### 투포인터란?

>[!NOTE]
>배열이나 리스트와 같은 선형 자료구조에서 두 개의 포인터를 이용해 원하는 결과를 얻는 알고리즘

이 두 포인터는 같은 방향으로 이동하거나(동일 방향 투포인터), 서로 반대 방향으로 이동하면서(양방향 투포인터) 문제를 해결합니다.

아래와 같은 상황에서 사용하면 좋습니다.

1. **부분 배열/문자열 문제**: 합이 특정 값인 부분 배열, 특정 문자로만 이루어진 가장 긴 부분 문자열
2. 고정 크기가 아닌 **가변 크기의 윈도우**가 필요한 경우
3. **정렬된 배열에서의 검색**: 두 수의 합이 특정 값과 같은 쌍 찾기, 세 수의 합이 0인 조합 찾기

### 의사코드
1. 시작(`start`)과 끝(`end`) 포인터를 모두 배열의 첫 위치(0)에서 시작
4. 현재 부분합(`curSum`)과 최소 길이(`minLength`) 초기화
5. `end` 포인터를 오른쪽으로 이동하며 부분합을 키움
6. 부분합이 `S` 이상이 되면
   - 현재 길이(`end-start+1`)와 저장된 최소 길이를 비교하여 더 작은 값을 유지
   - `start` 포인터를 오른쪽으로 이동시키면서 부분합에서 해당 값을 빼줌
   - 부분합이 `S` 미만이 될 때까지 이 과정을 반복
7. 최종적으로 찾은 최소 길이 반환 (찾지 못했다면 0 반환)

### 핵심 아이디어
투포인터 알고리즘의 효율성은 "불필요한 경우를 계산하지 않는다"는 점에서 나옵니다.

- `end` 포인터는 항상 오른쪽으로만 이동 => 모든 원소는 최대 한 번만 추가
- `start` 포인터도 항상 오른쪽으로만 이동하 => 모든 원소는 최대 한 번만 제거

**이로 인해 시간 복잡도가 O(N+N) = O(N)으로 최적화**

### 구현 중 바보짓
처음에는 내부 `while` 루프 조건과 포인터 이동 순서에서 혼란이 있었습니다. 처리 순서를 틀리게 해서 헤맸습니다.

- '합이 `S` 이상'이라는 조건을 while 루프에 적용하고, 포인터 이동 순서를 올바르게 조정해 해결
- 특히 `start` 포인터를 이동시키기 전에 해당 값을 `curSum`에서 빼는 순서가 중요했음