### PR TITLE
[태연] 250416

### DIFF
--- a/Baekjoon/250416_하늘에서_별똥별이_빗발친다/rhino-ty.js
+++ b/Baekjoon/250416_하늘에서_별똥별이_빗발친다/rhino-ty.js
@@ -1,0 +1,44 @@
+// 트램펄린에 부딪히는 최대 별똥별을 구해야함 => 완탐: 최댓값 변수를 두고, 0부터 N-K, M-K 만큼 돌면서 해야하나?
+//   근데 그러면 N * M * K^2이 돼서 시간 초과가 날 거 같음.
+// 무조건 별똥별이 있는 위치를 기준으로 배치하기 때문에 M*N의 별똥별 구역 전체를 도는 게 아닌, 별똥별 K번 순회하면서 하면 될 듯
+// 트램펄린을 두는 것도 각 별똥별 중앙이 아닌 두 별똥별 조합 x, y 좌표를 추출한 거로 별 계산
+
+// 1. 별똥별 K개의 좌표 (x, y) 저장
+// 2. 모든 별똥별 쌍에 대해 트램펄린 배치 시도하며 최대 별똥별 수 계산
+//   - 별똥별 i, j를 선택한 뒤 i의 x좌표와 j의 y좌표로 좌측 상단 모서리 배치
+//   - 이 배치에서 트램펄린 안에 들어오는 별똥별 수 세기
+// 3. 최대로 튕겨낼 수 있는 별똥별 수 찾고, 지구에 부딪히는 별똥별 수 계산
+
+function findMinStarsHitGround(N, M, L, K, stars) {
+  let maxStarsCaught = 0;
+
+  for (let i = 0; i < K; i++) {
+    for (let j = 0; j < K; j++) {
+      const starX = stars[i][0];
+      const starY = stars[j][1];
+
+      const starsCaughtCount = countStarInTrampoline(starX, starY, stars, L);
+
+      maxStarsCaught = Math.max(maxStarsCaught, starsCaughtCount);
+    }
+  }
+
+  return K - maxStarsCaught;
+}
+
+function countStarInTrampoline(starX, starY, stars, L) {
+  let count = 0;
+
+  for (const [x, y] of stars) {
+    if (starX >= x && starY >= y && starX <= x + L && starY <= y + L) count++;
+  }
+
+  return count;
+}
+
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().trim().split('\n');
+const [N, M, L, K] = input[0].split(' ').map(Number);
+const stars = input.slice(1).map((s) => s.split(' ').map(Number));
+
+console.log(findMinStarsHitGround(N, M, L, K, stars));


### PR DESCRIPTION
# 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #197 

## 문제 이해와 초기 접근법

이 문제는 N×M 크기의 구역에 떨어지는 K개의 별똥별을 L×L 크기의 트램펄린으로 최대한 많이 튕겨내야 하는 상황입니다. 처음에는 완전 탐색으로 모든 위치(0부터 N-L, M-L까지)에 트램펄린을 놓아보는 방법을 생각했지만, 이렇게 하면 시간 복잡도가 O(N×M×K^2)가 되어 N, M이 최대 500,000이고, K는 최대 100^2 이므로 시간 초과가 날 가능성이 높았습니다.

## 핵심 통찰: 별똥별 좌표 기반 접근법

문제 해결의 핵심 통찰은 **트램펄린의 최적 위치가 별똥별의 좌표와 직접적인 관련이 있다**는 것입니다. 특히, L×L 크기의 트램펄린을 배치할 때 가장 많은 별똥별을 포함하기 위해서는 트램펄린의 모서리나 경계선이 별똥별의 위치와 일치하는 경우가 최적해가 됩니다.

즉, 만약 트램펄린 내부에만 별똥별이 있고 경계에는 없다면, 트램펄린을 약간 움직여서 더 많은 별똥별을 포함할 가능성 존재 하기 때문에,
따라서 최적의 배치는 트램펄린의 경계에 별똥별이 위치한 경우입니다.

## 구현 전략

1. 모든 별똥별 쌍 (i, j)에 대해
   - 별똥별 i의 x좌표와 별똥별 j의 y좌표를 사용해 트램펄린의 좌측 상단 모서리 위치 결정
   - 이 위치에 L×L 크기의 트램펄린을 배치했을 때 포함되는 별똥별 수 계산
2. 이를 통해 최대로 튕겨낼 수 있는 별똥별 수를 찾고, 전체 별똥별 수에서 빼서 지구에 부딪히는 별똥별의 최소 수 산출

## 시간 복잡도 개선

이 방법은 N×M 전체를 순회하는 대신, K개의 별똥별 쌍만 고려하므로 시간 복잡도가 O(K²×K) = O(K³)가 됩니다. K는 최대 100이므로 1,000,000번 정도의 연산으로 해결 가능하여 효율적입니다.

## 구현 과정 고려사항

1. 트램펄린의 위치를 좌표로 나타내기
2. 별똥별이 트램펄린 내에 있는지 확인하는 조건 (좌표 범위 체크)
3. 모든 가능한 별똥별 쌍에 대한 조합 구현

이 접근법은 별똥별의 좌표를 최대한 활용하여 가능한 모든 트램펄린 배치 중 최적의 해를 찾아내는 방법입니다. 특히 완전 탐색의 범위를 N×M에서 K²로 줄여 효율성을 크게 개선했습니다.