### PR TITLE
[다솔] 250417

### DIFF
--- a/Programmers/250417_합승_택시_요금/dbjoung.js
+++ b/Programmers/250417_합승_택시_요금/dbjoung.js
@@ -1,0 +1,35 @@
+// 도착지점은 서로 겹치지 않음.
+// 지점 개수 3 이상 200 이하
+// s, a, b는 1 이상 n이하 자연수
+// fares 크기 n(n-1) / 2
+// cdf, dcf 공존 x
+
+function solution(N, S, A, B, fares) {
+  const board = new Array(N + 1)
+    .fill(null)
+    .map(() => new Array(N + 1).fill(Infinity));
+
+  for (const [c, d, f] of fares) {
+    board[c][d] = f;
+    board[d][c] = f;
+  }
+
+  for (let n = 1; n <= N; n++) {
+    for (let f = 1; f <= N; f++) {
+      for (let e = 1; e <= N; e++) {
+        if (f == e) {
+          board[f][e] = 0;
+          continue;
+        }
+        board[f][e] = Math.min(board[f][e], board[f][n] + board[n][e]);
+      }
+    }
+  }
+
+  let sum = Infinity;
+  for (let n = 1; n <= N; n++) {
+    sum = Math.min(sum, board[S][n] + board[n][A] + board[n][B]);
+  }
+
+  return sum;
+}


### PR DESCRIPTION
- 문제 이슈 넘버: #200 

## 풀이 시간
- 28분

## 풀이 방법
- 플로이드 워셜 알고리즘 사용
- A와 B의 출발지점은 같고, 각자의 집을 향해 갈 때 총 택시비를 구해야 한다.
- 처음부터 각자 택시타고 가거나, 어느 지점까지 합승했다가 합승종료지점부터 각자 택시를 타는 방법이 있다.
- 따라서 합승 종료 지점을 n, 출발지를 s, A와 B의 목적지를 각각 a, b라고 뒀을 때 최소 비용을 아래처럼계산할 수 있다. (board[s][e] = s부터 e까지 가는 최소 비용)
	- board[s][n]+board[n][a]+board[n][b]
- 플로이드-워셜은 각 노드에서 다른 각 노드로 이동하는 최소 비용을 구할 수 있는 알고리즘이므로, 이를 활용해 각 노드에서 다른 각 노드까지의 최소 비용을 구한 다음, n의 노드를 하나씩 대입해보며 위 공식의 최솟값을 찾는다.

## 시간복잡도
- 200 * 200 * 200 = 8,000,000