### PR TITLE
[태연] 250421

### DIFF
--- a/Baekjoon/250421_비슷한_단어/rhino-ty.js
+++ b/Baekjoon/250421_비슷한_단어/rhino-ty.js
@@ -1,0 +1,65 @@
+// 앞부분이 가장 많이 일치하는 두 단어를 찾는 것, 이중 반목문으로 그냥 구현하면 될 듯?
+// 1. 입력값 N과 N개의 영단어들을 배열로 저장
+// 2. 가장 긴 공통 접두사 길이와 해당하는 단어 쌍을 추적할 변수 선언 및 초기화
+// 3. 이중 반복문으로 모든 단어 쌍을 비교
+//   - 각 쌍마다 공통 접두사 길이 계산
+//   - 현재까지의 최대 길이보다 크면 최대값과 해당 단어 쌍 갱신
+// 4. 결과 출력
+
+function findMostSimilarWords(N, words) {
+  let maxPreLength = -1;
+  let firstWordIdx = -1;
+  let secondWordIdx = -1;
+
+  // for (let i = 0; i < N; i++) {
+  //   for (let j = 0; j < N; j++) {
+  //     if (i === j) continue; // 같은 단어는 비교하지 않음
+  for (let i = 0; i < N - 1; i++) {
+    for (let j = i + 1; j < N; j++) {
+      const preLength = getCommonPreLength(words[i], words[j]);
+
+      if (preLength > maxPreLength) {
+        maxPreLength = preLength;
+        firstWordIdx = i;
+        secondWordIdx = j;
+      }
+      // 접두사 길이가 같은 경우, 입력 순서를 고려
+      else if (preLength === maxPreLength) {
+        // 현재 단어 쌍의 첫 번째 단어가 이전 결과의 첫 번째 단어보다 입력 순서상 앞에 있는 경우
+        if (i < firstWordIdx) {
+          firstWordIdx = i;
+          secondWordIdx = j;
+        }
+        // 첫 번째 단어가 같고, 두 번째 단어가 이전 결과의 두 번째 단어보다 입력 순서상 앞에 있는 경우
+        else if (i === firstWordIdx && j < secondWordIdx) {
+          secondWordIdx = j;
+        }
+      }
+    }
+  }
+
+  return `${words[firstWordIdx]}\n${words[secondWordIdx]}`;
+}
+
+// 두 단어의 공통 접두사 길이 계산 함수
+function getCommonPreLength(word1, word2) {
+  let length = 0;
+  const minLength = Math.min(word1.length, word2.length);
+
+  for (let i = 0; i < minLength; i++) {
+    if (word1[i] === word2[i]) {
+      length++;
+    } else {
+      break;
+    }
+  }
+
+  return length;
+}
+
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().trim().split('\n');
+const N = parseInt(input[0]);
+const words = input.slice(1);
+
+console.log(findMostSimilarWords(N, words));


### PR DESCRIPTION
# 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #210

## 문제 이해 및 접근 방법
- N개의 영단어들 중에서 **가장 비슷한 두 단어**를 찾는 문제
- 두 단어의 비슷한 정도는 **공통 접두사의 길이**로 측정함
- 접두사란 두 단어의 앞부분에서 공통적으로 나타나는 부분문자열
- 접두사 길이가 최대인 경우가 여러 개일 때는 입력 순서대로 앞쪽에 있는 단어 쌍을 선택

처음에는 이 문제를 어떻게 최적화할 수 있을지 고민했습니다. 가능한 접근법들을 고려해봤습니다.

1. **브루트 포스 방식**: 모든 단어 쌍을 비교하여 공통 접두사 길이를 계산하는 방법 - $O(N²×L)$
2. **최적화된 브루트 포스**: 각 단어 쌍을 한 번만 비교 `(i,j)`와 `(j,i)`는 같으므로 - $O(N(N-1)/2×L)$
3. **정렬 기반 접근법**: 단어들을 정렬하여 인접한 단어들 간의 공통 접두사를 찾는 방법

정렬 기반 접근법도 고려했지만, 문제의 요구사항(입력 순서 유지)과 모든 단어 쌍을 비교해야 하는 필요성 때문에 결국 최적화된 브루트 포스 방식을 선택했습니다.

## 구현 과정
1. **초기화**: 최대 접두사 길이와 해당 단어 쌍의 인덱스를 추적할 변수 설정
2. **중복 없는 비교**: 모든 단어 쌍을 중복 없이 비교하기 위해 이중 반복문 최적화
   - `i`는 0부터 N-2까지, `j`는 i+1부터 N-1까지 순회
3. **접두사 길이 계산**: 각 단어 쌍마다 공통 접두사 길이를 계산
4. **최대값 갱신**: 더 긴 접두사를 찾으면 최대값과 해당 단어 쌍 갱신
5. **순서 고려**: 같은 길이의 접두사인 경우, 입력 순서를 고려하여 우선순위 결정

## 시간 복잡도 분석
- 최악의 경우: $O(N(N-1)/2 × L) ≈ O(N² × L)$
  - N: 단어의 개수 (최대 20,000)
  - L: 단어의 최대 길이 (최대 100)

최악의 경우 약 2억번의 문자 비교가 필요하지만, 실제로는 대부분의 단어 쌍이 초기에 비교가 종료되어 평균적으로 더 적은 연산이 필요합니다. 이중 반복문도 최적화해 같은 쌍을 두 번 비교하지 않도록 했기 때문에 실행 시간을 절반으로 줄일 수 있었습니다.