### PR TITLE
[태연] 250428

### DIFF
--- a/Baekjoon/250428_거짓말/rhino-ty.js
+++ b/Baekjoon/250428_거짓말/rhino-ty.js
@@ -1,0 +1,72 @@
+// 따로 알고리즘을 사용하지 않고 그냥 시뮬레이션으로 돌리면 될 듯, 입력 데이터도 작은 편이라 무지성 반복 ㄱㄱ
+// 진실을 말하면 무조건 말한 사람 Set에 집어넣기
+// 만일 Set에 has가 있다면, 진실을 말하고 그 인원들도 Set에 추가
+// has가 false라면 구라 말하기, Set에 안집어 넣어도 됨
+//   이때, 카운트 추가
+// 주의할점: 구라를 듣고, 진실을 들으면 안된다. 이후 진실을 들어야할 얘들도 예측해야함
+//   => while로 전체 진실을 알게 한 다음, 거짓말할 수 있는 파티를 카운트
+
+function getMaxCanLie(N, M, TPN, TP, parties) {
+  let truthToldPeople = new Set(TP);
+
+  let changed = true;
+  while (changed) {
+    const beforePeopleSize = truthToldPeople.size;
+
+    for (let i = 0; i < M; i++) {
+      const [PN, ...people] = parties[i];
+      const hasTruthPerson = people.some((person) => truthToldPeople.has(person));
+      if (hasTruthPerson) {
+        people.forEach((person) => truthToldPeople.add(person));
+      }
+    }
+
+    // 반복 종료
+    changed = beforePeopleSize !== truthToldPeople.size;
+  }
+
+  let lyingCount = 0;
+  for (let i = 0; i < M; i++) {
+    const [PN, ...people] = parties[i];
+    // 모든 참가자가 진실을 모르면 거짓말 가능
+    const canLie = !people.some((person) => truthToldPeople.has(person));
+    if (canLie) {
+      lyingCount++;
+    }
+  }
+  return lyingCount;
+}
+
+// function getMaxCanLie(N, M, TPN, TP, parties) {
+//   let lyingCount = 0;
+//   let truthToldPeople = new Set(TP);
+
+//   for (let i = 0; i < M; i++) {
+//     const [PN, ...people] = parties[i];
+//     let canLie = true;
+
+//     for (let j = 0; j < PN; j++) {
+//       if (truthToldPeople.has(people[j])) {
+//         canLie = false;
+//         break;
+//       }
+//     }
+
+//     // 거짓 불가: 진실만 말하기
+//     if (!canLie) {
+//       people.forEach((p) => truthToldPeople.add(p));
+//     }
+//     // 거짓 가능
+//     else {
+//       lyingCount++;
+//     }
+//   }
+
+//   return lyingCount;
+// }
+
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().split('\n');
+const [[N, M], [TPN, ...TP], ...parties] = input.map((i) => i.split(' ').map(Number));
+
+console.log(getMaxCanLie(N, M, TPN, TP, parties));


### PR DESCRIPTION
# 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #227 

이 문제는 지민이가 파티에서 진실 또는 과장된 이야기를 할 때, 거짓말쟁이로 알려지지 않으면서 최대한 많은 파티에서 과장된 이야기를 할 수 있는 수를 구하는 문제입니다.
주의할 점은 **거짓말을 듣고, 진실을 들으면 안됩니다**. 이후 진실을 들어야할 애들도 예측해서 전체 구라를 구해야합니다.

## 해결 접근법
진실을 아는 사람들의 집합이 파티를 통해 확장되는 과정을 시뮬레이션했습니다.

1. **집합(Set) 자료구조** 활용: 진실을 아는 사람들 관리
2. **반복 확산 알고리즘** 적용
   - 진실을 아는 사람들의 집합이 더 이상 변하지 않을 때까지 반복
   - 각 반복에서 진실을 아는 사람이 참석한 파티의 모든 참가자를 진실을 아는 사람들의 집합에 추가

## 핵심 인사이트
- **파티의 순서에 상관없이** 진실을 알게 되는 모든 사람들을 파악하는 것이 중요
- 모든 파티에서 **한 명이라도 진실**을 알면 그 파티의 **모든 참가자는 진실**을 들어야 함
- 파티 순서에 따른 의존성을 고려해 반복적으로 진실을 아는 사람들의 집합을 확장해야 함

## 시간 복잡도
- O(M * P * K)
  - M: 파티의 수
  - P: while 루프의 최대 반복 횟수 (최악의 경우 진실을 아는 사람 수와 비슷)
  - K: 각 파티의 평균 참가자 수

이 알고리즘은 문제의 제약 조건(N, M ≤ 50)에서 충분히 가능합니다.
