### PR TITLE
[미라] 250520

### DIFF
--- a/Baekjoon/250520_파일_합치기/ssum1ra.py
+++ b/Baekjoon/250520_파일_합치기/ssum1ra.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+T = int(input())
+for _ in range(T):
+    K = int(input())
+    C = list(map(int, input().split()))
+
+    prefix_sum = [0] * (K+1)
+    for i in range(1, K+1):
+        prefix_sum[i] = prefix_sum[i-1] + C[i-1]
+
+    dp = [[0] * (K+1) for _ in range(K+1)]
+
+    for l in range(2, K+1):
+        for i in range(1, K - l + 2):
+            j = i + l - 1
+            dp[i][j] = float('inf')
+            for k in range(i, j):
+                dp[i][j] = min(dp[i][j], dp[i][k] + dp[k+1][j] + (prefix_sum[j] - prefix_sum[i-1]))
+
+    print(dp[1][K])

--- a/Baekjoon/250520_파일_합치기/ssum1ra.py
+++ b/Baekjoon/250520_파일_합치기/ssum1ra.py
@@ -6,17 +6,26 @@ for _ in range(T):
     K = int(input())
     C = list(map(int, input().split()))
 
-    prefix_sum = [0] * (K+1)
-    for i in range(1, K+1):
-        prefix_sum[i] = prefix_sum[i-1] + C[i-1]
+    prefix_sum = [0] * (K + 1)
+    for i in range(1, K + 1):
+        prefix_sum[i] = prefix_sum[i - 1] + C[i - 1]
 
-    dp = [[0] * (K+1) for _ in range(K+1)]
+    dp = [[0] * (K + 1) for _ in range(K + 1)]
+    opt = [[0] * (K + 1) for _ in range(K + 1)]
 
-    for l in range(2, K+1):
-        for i in range(1, K - l + 2):
-            j = i + l - 1
+    for i in range(1, K + 1):
+        opt[i][i] = i
+
+    for length in range(2, K + 1):
+        for i in range(1, K - length + 2):
+            j = i + length - 1
             dp[i][j] = float('inf')
-            for k in range(i, j):
-                dp[i][j] = min(dp[i][j], dp[i][k] + dp[k+1][j] + (prefix_sum[j] - prefix_sum[i-1]))
+            for k in range(opt[i][j - 1], opt[i + 1][j] + 1):
+                if k >= j:
+                    continue
+                cost = dp[i][k] + dp[k + 1][j] + (prefix_sum[j] - prefix_sum[i - 1])
+                if cost < dp[i][j]:
+                    dp[i][j] = cost
+                    opt[i][j] = k
 
     print(dp[1][K])

--- a/Baekjoon/250520_파일_합치기/ssum1ra.py
+++ b/Baekjoon/250520_파일_합치기/ssum1ra.py
@@ -22,7 +22,7 @@ for _ in range(T):
             dp[i][j] = float('inf')
             for k in range(opt[i][j - 1], opt[i + 1][j] + 1):
                 if k >= j:
-                    continue
+                    break
                 cost = dp[i][k] + dp[k + 1][j] + (prefix_sum[j] - prefix_sum[i - 1])
                 if cost < dp[i][j]:
                     dp[i][j] = cost


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #260 

# 풀이 과정
## pypy3 풀이
```py
for l in range(2, K+1):
        for i in range(1, K - l + 2):
            j = i + l - 1
            dp[i][j] = float('inf')
            for k in range(i, j):
                dp[i][j] = min(dp[i][j], dp[i][k] + dp[k+1][j] + (prefix_sum[j] - prefix_sum[i-1]))
```

- i번부터 j번까지 파일을 하나로 합치려면, 중간에 k를 기준으로 두 덩어리로 나누고, 각각을 최소 비용으로 합친 뒤, 그 둘을 한 번 더 합쳐야 한다.
- 이 마지막 합치는 비용은 전체 구간의 크기이므로 sum(i~j)을 더해주고, 가능한 k들 중 최소를 선택한다.

## python3 풀이
### Knuth Optimization 활용
- 파일 합치기 문제에서는 구간이 커질수록 최적의 분할점 k도 오른쪽으로 이동하는 경향이 있다.
- 최적의 k가 어디 있는지 이미 좁혀져 있으니까 전체 i ~ j를 다 볼 필요 없이 
- opt[i][j - 1] ~ opt[i + 1][j] 사이에서만 보면 돼서 시간 복잡도가 O(N³) → O(N²)로 줄어든다.

# 풀이 시간
- 1시간 + α