### PR TITLE
[선아] 250604

### DIFF
--- a/Baekjoon/250604_숨바꼭질_4/choiseona.js
+++ b/Baekjoon/250604_숨바꼭질_4/choiseona.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const [meta] = fs.readFileSync("./input.txt").toString().trim().split("\n");
+const [N, K] = meta.split(" ").map(Number);
+const size = 100001;
+
+const BFS = (start, end) => {
+  const visited = Array.from({ length: size }, () => false);
+  const parent = Array.from({ length: size }, () => undefined);
+  const queue = [[start, 0]];
+  visited[start] = true;
+
+  while (queue.length > 0) {
+    const [pos, count] = queue.shift();
+    if (pos === end) return [count, parent];
+
+    for (const next of [pos - 1, pos + 1, 2 * pos]) {
+      if (visited[next]) continue;
+      if (next < 0 || next >= size) continue;
+
+      parent[next] = pos;
+      queue.push([next, count + 1]);
+      visited[next] = true;
+    }
+  }
+};
+
+const [count, parent] = BFS(N, K);
+const countString = `${count}\n`;
+let pathString = "";
+
+let curr = K;
+const path = [];
+while (curr >= 0) {
+  path.push(curr);
+  curr = parent[curr];
+}
+pathString += path.reverse().join(" ");
+console.log(countString + pathString);

--- a/Programmers/250604_의상/choiseona.js
+++ b/Programmers/250604_의상/choiseona.js
@@ -1,0 +1,15 @@
+function solution(clothes) {
+  const clothesMap = new Map();
+  let totalCombinations = 1;
+  const NOTHING = 1;
+
+  clothes.forEach(([_, clothesType]) => {
+    clothesMap.set(clothesType, (clothesMap.get(clothesType) || 0) + 1);
+  });
+
+  for (let [_, value] of clothesMap) {
+    totalCombinations *= value + 1;
+  }
+
+  return totalCombinations - NOTHING;
+}

--- a/Programmers/250604_전화번호_목록/choiseona.js
+++ b/Programmers/250604_전화번호_목록/choiseona.js
@@ -1,0 +1,9 @@
+function solution(phone_book) {
+  phone_book.sort();
+
+  for (let i = 0; i < phone_book.length; i++) {
+    if (phone_book[i + 1]?.indexOf(phone_book[i]) === 0) return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #293 

<!-- 알고리즘 접근법 및 풀이과정을 작성해주세요. -->

## 숨바꼭질4 (#293)

### 풀이 시간 

40분

### 풀이 방법

### 1. BFS (너비 우선 탐색)
- 모든 간선의 가중치가 동일하므로, 최단 경로를 구하는 데 BFS가 적절
- BFS로 탐색하면서 방문한 노드를 기록하고, 각 노드에 대해 **어디서 왔는지(parent)**를 저장

### 2. 방문 배열
- 이미 방문한 위치는 다시 방문하지 않기 위해 `visited` 배열 사용 (`O(1)` 조회 성능).

### 3. 경로 추적
- BFS 종료 시점에 도착한 노드 `K`에서부터 `parent` 배열을 따라 `N`까지 거꾸로 올라가며 경로를 복원
- 이때 경로는 역순이기 때문에 `reverse()`로 정렬하여 출력

## 전화번호 목록(#295)

### 풀이 방법 

### 1. 사전순 정렬
- 문자열을 **사전순으로 정렬**하면, 접두어 관계가 있다면 반드시 **바로 인접한 항목** 사이에 존재
- 예를 들어 `["119", "1195524421", "97674223"]`으로 정렬되면 `119`와 `1195524421`을 비교하면 바로 확인 가능.

### 2. 접두어 검사
- 인접한 두 전화번호 (`i`, `i+1`)를 비교하면서 `phone_book[i+1].indexOf(phone_book[i]) === 0`인 경우,
  - `phone_book[i]`가 `phone_book[i+1]`의 접두어라는 의미이므로, false를 반환

## 의상(#296)

### 풀이 방법

### 1. 종류별 의상 개수 세기
- `Map` 을 사용해 각 의상 종류별로 몇 개의 아이템이 있는지 셈 

### 2. 조합 개수 계산
- 각 종류에서 **해당 의상을 입지 않는 경우(=1)** 도 포함하여 `(의상 개수 + 1)` 을 곱함 
- 예) 얼굴(2개), 상의(1개), 하의(1개), 겉옷(1개)  
  → (2+1) * (1+1) * (1+1) * (1+1) = 3 * 2 * 2 * 2 = 24가지

### 3. 최소 한 가지는 입어야 하므로, 모두 안 입는 경우(1가지)를 뺌 
- 최종 조합 수 = 전체 경우의 수 - 1