### PR TITLE
[다솔] 250606

### DIFF
--- a/Baekjoon/250430_강의실_배정/dbjoung.js
+++ b/Baekjoon/250430_강의실_배정/dbjoung.js
@@ -1,0 +1,26 @@
+let [N, ...ST] = require('fs').readFileSync(0).toString().trim().split('\n');
+N = Number(N);
+ST = ST.map(line => line.split(' ').map(Number));
+
+const events = [];
+
+for (const [s, t] of ST) {
+    events.push([s, 'start']);
+    events.push([t, 'end']);
+}
+
+// 시간 기준 정렬. 같은 시간이면 'end' 먼저 와야 강의실 재사용 가능
+events.sort((a, b) => {
+    if (a[0] === b[0]) return a[1] === 'end' ? -1 : 1;
+    return a[0] - b[0];
+});
+
+let count = 0;
+let result = 0;
+for (const [time, type] of events) {
+    if (type === 'start') count++;
+    else count--;
+    result = Math.max(result, count);
+}
+
+console.log(result);

--- a/Baekjoon/250514_저울/dbjoung.js
+++ b/Baekjoon/250514_저울/dbjoung.js
@@ -1,0 +1,40 @@
+// 무게가 서로 다른 N개의 물건. 1부터 N까지의 번호가 붙음
+// 일부 물건 쌍의 양팔 저울 결과표. 비교 결과가 모순되는 입력은 없음
+// 각 물건에 대해, 그 물건과의 비교 결과를 알수 없는 물건의 개수 출력
+// 입력은 >
+// 플로이드-워셜
+// 1>2, 2>3, 3>4, 5>4, 6>5
+
+let [N, M, ...comps] = require('fs').readFileSync(0).toString().trim().split('\n');
+N = Number(N);
+M = Number(M);
+
+const d = Array.from({ length: N + 1 }, () => Array(N + 1).fill(false));
+
+for (const comp of comps) {
+    const [s, e] = comp.split(' ').map(Number);
+    d[s][e] = true;  // s > e
+}
+
+for (let mid = 1; mid <= N; mid++) {
+    for (let s = 1; s <= N; s++) {
+        for (let e = 1; e <= N; e++) {
+            if (d[s][mid] && d[mid][e]) {
+                d[s][e] = true;
+            }
+        }
+    }
+}
+
+const result = [];
+
+for (let i = 1; i <= N; i++) {
+    let count = 0;
+    for (let j = 1; j <= N; j++) {
+        if (i === j) continue;
+        if (d[i][j] || d[j][i]) count++;  // i > j or i < j
+    }
+    result.push(N - 1 - count);  // 비교 불가능한 개수
+}
+
+console.log(result.join('\n'));

--- a/Baekjoon/250521_단어_섞기/dbjoung.cpp
+++ b/Baekjoon/250521_단어_섞기/dbjoung.cpp
@@ -1,0 +1,45 @@
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace std;
+
+bool canMake(char (*s)[402]) {
+    int len1 = strlen(s[0]);
+    int len2 = strlen(s[1]);
+    int len3 = strlen(s[2]);
+    
+    vector<vector<bool>> d(202, vector(202, false));
+
+    d[0][0] = true;
+
+    for (int i1 = 0 ; i1 <= len1 ; i1++) {
+        for (int i2 = 0 ; i2 <= len2 ; i2++) {
+            if (d[i1][i2] && s[0][i1] == s[2][i1+i2]) d[i1+1][i2] = true;
+            if (d[i1][i2] && s[1][i2] == s[2][i1+i2]) d[i1][i2+1] = true;
+        }
+    }
+    
+    return d[len1][len2];
+    
+}
+
+int main() {
+    int N;
+    scanf("%d", &N);
+
+    vector<bool> result;
+    for (int n=0 ; n<N ; n++) {
+        char s[3][402];
+        for (int i=0 ; i<=2 ; i++) {
+            scanf("%s", s[i]);
+        }
+
+        if (canMake(s)) result.push_back(true);
+        else result.push_back(false);
+    }
+
+    for (int i=0 ; i<result.size() ; i++) {
+        printf("Data set %d: %s\n", i+1, (result[i]) ? "yes" : "no");
+    }
+}

--- a/Baekjoon/250526_여행_가자/dbjoung.cpp
+++ b/Baekjoon/250526_여행_가자/dbjoung.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <cmath>
+
+int main() {
+    int N, M;
+    scanf("%d\n%d", &N, &M);
+
+    int board[N+1][N+1];
+
+    for (int i=1 ; i<=N ; i++) {
+        for (int j=1 ; j<=N ; j++) {
+            scanf("%d", &board[i][j]);
+            if (i==j) board[i][j] = 1;
+        }
+    }
+
+    int roads[M];
+    for (int i=0 ; i<M ; i++) {
+        scanf("%d", &roads[i]);
+    }
+
+    for (int i=1 ; i<=N ; i++) {
+        for (int s=1 ; s<=N ; s++) {
+            for (int e=1 ; e<=N ; e++) {
+                if (board[s][e] || (board[s][i] && board[i][e])) board[s][e] = 1;
+            }
+        }
+    }
+
+    int result = 1;
+    for (int i=1 ; i<M ; i++) {
+        if (board[roads[i-1]][roads[i]]==0) {
+            result = 0;
+            break;
+        }
+    }
+
+    if (result == 1) printf("YES");
+    else printf("NO");
+}

--- a/Baekjoon/250528_좋다/dbjoung.cpp
+++ b/Baekjoon/250528_좋다/dbjoung.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+int main() {
+    int N;
+    scanf("%d", &N);
+
+    int A[N];
+    for (int i=0 ; i<N ; i++) {
+        scanf("%d", &A[i]);
+    }
+
+    sort(A, A+N);
+    int count = 0;
+    for (int i=0 ; i<N ; i++) {
+        int left = 0, right = N-1;
+        if (i==left) left++;
+        if (i==right) right--;
+        while(left<right) {
+            int sum = A[left] + A[right];
+            if (sum == A[i]) {
+                count++;
+                break;
+            } else if (sum < A[i]) {
+                if (left+1==i) left+=2;
+                else left++;
+            } else {
+                if (right-1==i) right-=2;
+                else right--;
+            } 
+        }
+    }
+
+    printf("%d", count);
+}

--- a/Baekjoon/250530_새로운_게임_2/dbjoung.js
+++ b/Baekjoon/250530_새로운_게임_2/dbjoung.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().trim().split('\n');
+
+const [N, K] = input[0].split(' ').map(Number);
+const table = input
+  .slice(1, 1 + N)
+  .map(line => line.split(' ').map(Number));
+
+const players = new Array(K + 1);
+for (let i = 1; i <= K; i++) {
+  const [x, y, d] = input[1 + N + i - 1].split(' ').map(Number);
+  players[i] = [x, y, d]; 
+}
+
+const board = new Array(N + 1);
+for (let i = 1; i <= N; i++) {
+  board[i] = new Array(N + 1);
+  for (let j = 1; j <= N; j++) {
+    board[i][j] = []; 
+  }
+}
+
+for (let i = 1; i <= K; i++) {
+  const [x, y, _] = players[i];
+  board[x][y].push(i);
+}
+
+const dir = [
+  null,
+  [0, 1],
+  [0, -1],
+  [-1, 0],
+  [1, 0],
+];
+
+const rdir = [null, 2, 1, 4, 3];
+
+function getMovePlayer(originList, player) {
+  for (let i = 0; i < originList.length; i++) {
+    if (originList[i] === player) {
+      return originList.splice(i);
+    }
+  }
+  return [];
+}
+
+function movePlayers(movePs, destinationList) {
+  destinationList.push(...movePs);
+  return destinationList.length;
+}
+
+for (let turn = 1; turn <= 1000; turn++) {
+  for (let playerIndex = 1; playerIndex <= K; playerIndex++) {
+    let [curX, curY, curD] = players[playerIndex];
+
+    let nextX = curX + dir[curD][0];
+    let nextY = curY + dir[curD][1];
+
+    let movePs = null;   
+    let color = null;    
+
+    if (
+      nextX < 1 || nextX > N ||
+      nextY < 1 || nextY > N ||
+      table[nextX - 1][nextY - 1] === 2
+    ) {
+      const newD = rdir[curD];
+      players[playerIndex][2] = newD;
+      curD = newD; 
+
+      nextX = curX + dir[curD][0];
+      nextY = curY + dir[curD][1];
+
+      if (
+        nextX < 1 || nextX > N ||
+        nextY < 1 || nextY > N ||
+        table[nextX - 1][nextY - 1] === 2
+      ) {
+        continue;
+      }
+
+      color = table[nextX - 1][nextY - 1];
+      movePs = getMovePlayer(board[curX][curY], playerIndex);
+      if (color === 1) {
+        movePs.reverse();
+      }
+    }
+    else if (table[nextX - 1][nextY - 1] === 0) {
+      color = 0;
+      movePs = getMovePlayer(board[curX][curY], playerIndex);
+    }
+    else {
+      color = 1;
+      movePs = getMovePlayer(board[curX][curY], playerIndex);
+      movePs.reverse();
+    }
+
+    movePs.forEach(idx => {
+      players[idx][0] = nextX;
+      players[idx][1] = nextY;
+    });
+
+    const stackSize = movePlayers(movePs, board[nextX][nextY]);
+    if (stackSize >= 4) {
+      console.log(turn);
+      return;
+    }
+  }
+}
+
+console.log(-1);

--- a/Baekjoon/250602_운동/dbjoung.cpp
+++ b/Baekjoon/250602_운동/dbjoung.cpp
@@ -1,0 +1,43 @@
+#define _CRT_SECURE_NO_WARNINGS
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <limits>
+
+using namespace std;
+
+int main()
+{   
+    int V, E;
+    scanf("%d %d", &V, &E);
+
+
+    int map[401][401];
+    fill(&map[0][0], &map[0][0] + 401 * 401, numeric_limits<int>::max());
+
+    for (int e = 0; e < E; e++) {
+        int a, b, c;
+        scanf("%d %d %d", &a, &b, &c);
+
+        map[a][b] = c;
+    }
+
+    for (int c = 1; c <= V; c++) {
+        for (int s = 1; s <= V; s++) {
+            for (int e = 1; e <= V; e++) {
+                int sum = map[s][c] + map[c][e];
+                if (sum < 1) sum = numeric_limits<int>::max();
+                if (sum < map[s][e]) map[s][e] = sum;
+            }
+        }
+    }
+
+    int minRoute = numeric_limits<int>::max();
+    for (int v = 1; v <= V; v++) {
+        minRoute = min(minRoute, map[v][v]);
+    }
+    
+    if (minRoute != numeric_limits<int>::max()) printf("%d", minRoute);
+    else printf("-1");
+    return 0;
+}

--- a/Baekjoon/250606_정육점/dbjoung.cpp
+++ b/Baekjoon/250606_정육점/dbjoung.cpp
@@ -1,0 +1,65 @@
+// 1시간 10분 소요.. ㅠㅠ
+
+#include <iostream>
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <limits>
+typedef unsigned uint;
+
+using namespace std; 
+
+struct Comp {  
+    bool operator()(pair<int, int>& a, pair<int, int>& b) {
+        if (a.second < b.second) return true;
+        else if (a.second == b.second) {
+            if (a.first > b.first) return true;
+        }
+
+        return false;
+    }
+};
+
+int main() {
+
+    uint N, M;
+    scanf("%d %d", &N, &M);
+
+    vector<pair<int, int>> items;
+
+    for (uint n=0 ; n<N ; n++) {
+        uint w, p;
+        scanf("%d %d", &w, &p);
+
+        items.push_back(make_pair(w, p));
+    }
+
+    sort(items.begin(), items.end(), Comp());
+
+    uint result = (uint)numeric_limits<int>::max()+1;
+
+    uint subSum = 0;
+    uint curPrice = 0;
+    uint subPrice = 0;
+    uint totalSum = 0;
+    for (uint i=0 ; i<items.size() ; i++) {
+        if (curPrice!=items[i].second) {
+            totalSum += subSum;
+            subSum = 0;
+            curPrice = items[i].second;
+            subPrice = 0;
+        }
+
+        subSum += items[i].first;
+        subPrice += items[i].second;
+
+        if (totalSum + subSum >= M) {
+            result = min(result, subPrice);
+        } 
+    }
+
+    if (result == (uint)numeric_limits<int>::max()+1) result = -1;
+    printf("%d", result);
+
+    return 0;
+}


### PR DESCRIPTION
### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #302 
- 풀이 시간 : 1시간 10분 (ㅠㅠ)
- 접근 : 
	- 은혜가 정육점에서 p원짜리 고기 덩어리를 구매하면, p원 미만 가격의 고기 덩어리들도 모두 서비스로 받을 수 있음.
	- 따라서 고기 덩어리를 가격 순으로 오름차순 정렬, 무게 순으로 내림차순 정렬한 다음, 누적합을 사용. 누적합이 은혜가 구매해야하는 양보다 같거나 커지는 시점의 가격을 출력한다.
- 풀이 :
	- items 배열에 각 덩어리를 무게, 가격 쌍으로 저장
	- 가격 오름차순, 무게 내림차순으로 items 배열 정렬
	- 최소 지불 비용에 int형의 최대값+1을 넣는다. (최대 무게가 int형의 최대값이므로)
	- items 배열을 순회하면서 totalSum, subSum, subPrice을 구한다. 
		- totalSum : 서비스로 얻을 수 있는 고기의 총 무게
		- subSum : 은혜가 실제로 구매하려는 고기의 총 무게
		- subPrice : 은혜가 실제로 구매하려는 고기의 총 가격
	- 배열을 순회하다가, totalSum + subSum의 값이 은혜가 구매해야하는 양(M)보다 같거나 커지면 그 순간의 subPrice를 result에 저장한다.
		- 단, 이에 해당하는 경우는 여러개 있을 수 있고, 최솟값을 구하기 위해 min 함수 사용
- 시간 복잡도 : 정렬에 필요한 nlogn. (100,000 x log100,000)

---

### 🍳 Algorithm approach and solution

- 문제 이슈 넘버: #300 
- 풀이 시간 : (측정 안함.. 3-40분 정도 걸린 것 같음)
- 접근 : 
	- 맵을 사용해서 각 장르의 노래 분류해줌
- 풀이 :
	- map에 장르명을 키로, 총 재생수와 {인덱스, 조회수} 쌍으로 값 넣음
		- ` map<string, pair<int, vector<pair<int, int>>>>`
	- genres, plays 순회하면서 map에 값 저장
	- 장르 배열 따로 선언해서 총 재생수 순으로 정렬
	- 정렬 후, 해당 장르 순으로 map 탐색하며 재생수 정렬 & 앞 2개 인덱스 구하기
- 시간복잡도 : 100 * 10000log10000 
